### PR TITLE
Caching of the HTTP call

### DIFF
--- a/cats/api_query.py
+++ b/cats/api_query.py
@@ -16,9 +16,9 @@ def get_tuple(postcode) -> list[tuple[str, int]]:
     # the current hour or half hour in UTZ
     dt = datetime.now(timezone.utc)
     if dt.minute > 30:
-        dt.replace(minute=30, second=0, microsecond=0)
+        dt = dt.replace(minute=31, second=0, microsecond=0)
     else:
-        dt.replace(minute=0, second=0, microsecond=0)
+        dt = dt.replace(minute=1, second=0, microsecond=0)
     timestamp = dt.strftime("%Y-%m-%dT%H:%MZ")
 
     # Setup a session for the HTTP cache

--- a/cats/api_query.py
+++ b/cats/api_query.py
@@ -22,7 +22,7 @@ def get_tuple(postcode) -> list[tuple[str, int]]:
     timestamp = dt.strftime("%Y-%m-%dT%H:%MZ")
 
     # Setup a session for the HTTP cache
-    session = requests_cache.CachedSession('cats_cache')
+    session = requests_cache.CachedSession('cats_cache', use_temp=True)
     # get the carbon intensity api data
     r = session.get(
         "https://api.carbonintensity.org.uk/regional/intensity/"

--- a/cats/api_query.py
+++ b/cats/api_query.py
@@ -1,5 +1,5 @@
-import requests
-from datetime import datetime
+import requests_cache
+from datetime import datetime, timezone
 from .parsedata import writecsv
 
 
@@ -12,9 +12,19 @@ def get_tuple(postcode) -> list[tuple[str, int]]:
     # just get the first part of the postcode
     postcode = postcode.split()[0]
     
+    # get the time (as a datetime object) for the top of
+    # the current hour or half hour in UTZ
+    dt = datetime.now(timezone.utc)
+    if dt.minute > 30:
+        dt.replace(minute=30, second=0, microsecond=0)
+    else:
+        dt.replace(minute=0, second=0, microsecond=0)
+    timestamp = dt.strftime("%Y-%m-%dT%H:%MZ")
+
+    # Setup a session for the HTTP cache
+    session = requests_cache.CachedSession('cats_cache')
     # get the carbon intensity api data
-    timestamp = datetime.utcnow().strftime("%Y-%m-%dT%H:%MZ")
-    r = requests.get(
+    r = session.get(
         "https://api.carbonintensity.org.uk/regional/intensity/"
         + timestamp
         + "/fw48h/postcode/"

--- a/cats/api_query.py
+++ b/cats/api_query.py
@@ -4,16 +4,28 @@ from .parsedata import writecsv
 
 
 def get_tuple(postcode) -> list[tuple[str, int]]:
-    """gets carbon intensity API data for the next 48 hours from carbonintensity.org.uk
-    param postcode: the UK post code (just the first section) of the location, e.g. M15
+    """
+    get carbon intensity from carbonintensity.org.uk
+
+    Given the postcode and current time, return a set of predictions of the
+    future carbon intensity. This wraps the API from carbonintensity.org.uk
+    and is set up to cache data from call to call even accross different
+    processes within the same half hour window. The returned prediction data
+    is in half hour blocks starting from the half hour containing the current
+    time and extending for 48 hours into the future.
+
+    param postcode: UK post code (just the first section), e.g. M15
     returns: a set of tuples with start time and carbon intensity
     """
-
-    # just get the first part of the postcode
+    # just get the first part of the postcode, assume spaces are included
     postcode = postcode.split()[0]
     
-    # get the time (as a datetime object) for the top of
-    # the current hour or half hour in UTZ
+    # get the time (as a datetime object) and update this to be the 'top' of
+    # the current hour or half hour in UTZ plus one minute. So a call at 
+    # 17:47 BST will yield a timestamp of 16:31 UTC. This means that within
+    # any given half hour we will always use the same timestamp. As this 
+    # becomes part of the URL, calls can be cached using standard HTTP 
+    # caching layers
     dt = datetime.now(timezone.utc)
     if dt.minute > 30:
         dt = dt.replace(minute=31, second=0, microsecond=0)
@@ -21,7 +33,8 @@ def get_tuple(postcode) -> list[tuple[str, int]]:
         dt = dt.replace(minute=1, second=0, microsecond=0)
     timestamp = dt.strftime("%Y-%m-%dT%H:%MZ")
 
-    # Setup a session for the HTTP cache
+    # Setup a session for the API call. This uses a global HTTP cache
+    # with the URL as the key. Failed attempts are not cahched.
     session = requests_cache.CachedSession('cats_cache', use_temp=True)
     # get the carbon intensity api data
     r = session.get(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@
   requires-python = ">=3.9"
   readme = "README.md"
   classifiers = ["License :: OSI Approved :: MIT License"]
-  dependencies = ["requests>=2.0.0", "PyYAML>=6.0"]
+  dependencies = ["requests-cache>=1.0", "PyYAML>=6.0"]
 
   [project.optional-dependencies]
     test = ["pytest"]

--- a/tests/test_api_query.py
+++ b/tests/test_api_query.py
@@ -1,0 +1,12 @@
+import cats
+
+def test_api_call():
+    """
+    This just checks the API call runs and returns a list of tuples
+    """
+
+    response = cats.api_query.get_tuple('OX1')
+
+    assert isinstance(response, list) 
+    for item in response:
+        assert isinstance(item, tuple) 


### PR DESCRIPTION
This is a simple way to cache the API request in a way that would be useable on a multi-user system. There are two 'bits'. First, we make the request for the 'top' of the half hour (so hh:00:00 or hh:30:00) by changing the current time before calling the API, then we make the call through requests_cache rather than requests. Because the time (and postcode) is
part of the request this means that old data is
reused, avoiding the HTTP call.

Currently the results are just in file `cats_cache.sqlits` in the current working directory, but we could put this in a hidden file in the users homespace, or in a global temporary directory or whatever.

At this stage think of this as a proof of concept. There are bits that need thinking about (where to put the cache, cleaning up the cache, install the right modules etc.)