### PR TITLE
Modify output to be compatible with -t option of at(1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **C**limate-**A**ware **T**ask **S**cheduler
 
-CATS is a Climate-Aware Task Scheduler. It schedules cluster jobs to minimize predicted carbon intensity of running the process. It was created as part of the [2023 Collaborations Workshop](https://software.ac.uk/cw23). 
+CATS is a Climate-Aware Task Scheduler. It schedules cluster jobs to minimize predicted carbon intensity of running the process. It was created as part of the [2023 Collaborations Workshop](https://software.ac.uk/cw23).
 
 Currently CATS only works in the UK, if you are aware of APIs for realtime grid carbon intensity data in other countries please open an issue and let us know.
 
@@ -10,14 +10,19 @@ Currently CATS only works in the UK, if you are aware of APIs for realtime grid 
 
 The Climate-Aware Task Scheduler is a lightweight Python package designed to schedule tasks based on the estimated carbon intensity of the electricity grid at any given moment. This tool uses real-time carbon intensity data from the National Grid ESO via their API to estimate the carbon intensity of the electricity grid, and schedules tasks at times when the estimated carbon intensity is lowest. This helps to reduce the carbon emissions associated with running computationally intensive tasks, making it an ideal solution for environmentally conscious developers.
 ***
+
 ## Features
+
 - Estimates the carbon intensity of the electricity grid in real-time
 - Schedules tasks based on the estimated carbon intensity, minimizing carbon emissions
 - Provides a simple and intuitive API for developers
 - Lightweight and easy to integrate into existing workflows
 - Supports Python 3.9+
+
 ***
+
 ## Installation
+
 Install via `pip` as follows:
 
 ```bash
@@ -25,6 +30,7 @@ pip install git+https://github.com/GreenScheduler/cats
 ```
 
 ***
+
 ## Quickstart
 
 You can run `cats` with:
@@ -33,13 +39,14 @@ You can run `cats` with:
 python -m cats -d <job_duration> --loc <postcode>
 ```
 
-The postcode is optional, and can be pulled from the `config.yml` file or, if that is not present, inferred using the server IP address.
+The postcode is optional, and can be pulled from the `config.yml` file or, if that is not present, inferred using the server IP address. Job duration is in minutes, specified as an integer.
 
 The scheduler then calls a function that estimates the best time to start the job given predicted carbon intensity over the next 48 hours. The workflow is the same as for other popular schedulers. Switching to `cats` should be transparent to cluster users.
 
 It will display the time to start the job on standard out and optionally some information about the carbon intensity on standard error.
 
 ***
+
 ### Display carbon footprint estimates
 
 Optionally, `cats` will soon be able to provide an estimate for the carbon footprint reduction resulting from delaying your job.  To enable the footprint estimation, you must provide information about the machine in the form of a YAML configuration file.  An example is given below:
@@ -70,7 +77,6 @@ partitions:
 
 Use the `--config` option to specify a path to the config file, relative to the current directory. If no path is specified, `cats` looks for a file named `config.yml` in the current directory.
 
-
 Additionally, to obtain carbon footprints, job-specific information must be provided to `cats` through the `--jobinfo` option.  The example below demonstrates running `cats` with footprint estimation for a job using 8GB of memory, 2 CPU cores and no GPU:
 
 ```bash
@@ -78,19 +84,28 @@ cats -d 120 --config .config/config.yml \
   --jobinfo cpus=2,gpus=0,memory=8,partition=CPU_partition
 ```
 
-
 ***
+
 ### Using with the `at` scheduler
 
 You can use cats with the `at` job scheduler by running:
 
 ```bash
-command | at `python -m cats -d <job_duration> --loc <postcode>
+command | at -t `python -m cats -d <job_duration> --loc <postcode>`
+```
+
+As an example, if you want to schedule a run of `ls` with a 5 minute duration, in the OX1 postcode
+that would look like
+
+```bash
+ls | at -t `python -m cats -d 5 --loc OX1`
 ```
 
 ## Contributing
+
 We welcome contributions from the community! If you find a bug or have an idea for a new feature, please open an issue on our GitHub repository or submit a pull request.
 ***
+
 ## License
 
 [MIT License](https://github.com/GreenScheduler/cats/blob/main/LICENSE)

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -114,7 +114,8 @@ def main(arguments=None):
 #        ]
 #    )
 
-    print(f"Best job start time: {starttime}")
+    sys.stderr.write(f"Best job start time: {starttime}\n")
+    print(f"{starttime:%m%d%H%M}")  # for POSIX compatibility with at -t
 
     if args.jobinfo:
         jobinfo = validate_jobinfo(args.jobinfo)

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -115,7 +115,7 @@ def main(arguments=None):
 #    )
 
     sys.stderr.write(f"Best job start time: {starttime}\n")
-    print(f"{starttime:%m%d%H%M}")  # for POSIX compatibility with at -t
+    print(f"{starttime:%Y%m%d%H%M}")  # for POSIX compatibility with at -t
 
     if args.jobinfo:
         jobinfo = validate_jobinfo(args.jobinfo)


### PR DESCRIPTION
at(1) time syntax differs between macOS and Linux. Output the time
in MMDDhhmm format that can be passed to the POSIX standard -t option
which works across both.

This also updates the documentation to clarify that job duration
is in minutes and adds an example.

Fixes: #33, #34
