### PR TITLE
Enable extension to other carbon intensity forecast providers

### DIFF
--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -7,7 +7,7 @@ import yaml
 import sys
 
 from .timeseries_conversion import cat_converter  # noqa: F401
-from .api_query import get_tuple  # noqa: F401
+from .api_query import get_tuple, ciuk_parse_data_from_json, ciuk_request_url  # noqa: F401
 from .parsedata import writecsv  # noqa: F401
 from .carbonFootprint import greenAlgorithmsCalculator
 
@@ -15,7 +15,11 @@ from .carbonFootprint import greenAlgorithmsCalculator
 
 
 def findtime(postcode, duration):
-    tuples = get_tuple(postcode)
+    tuples = get_tuple(
+        postcode,
+        request_url=ciuk_request_url,
+        parse_data_from_json=ciuk_parse_data_from_json,
+    )
     result = writecsv(tuples, duration)
     sys.stderr.write(str(result) + "\n")
     return result["timestamp"]

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -7,18 +7,19 @@ import yaml
 import sys
 
 from .timeseries_conversion import cat_converter  # noqa: F401
-from .api_query import get_tuple, ciuk_parse_data_from_json, ciuk_request_url  # noqa: F401
+from .api_query import get_tuple
+from .api_interface import API_interfaces
 from .parsedata import writecsv  # noqa: F401
 from .carbonFootprint import greenAlgorithmsCalculator
 
 # from cats import findtime
 
 
-def findtime(postcode, duration):
+def findtime(postcode, duration, api_interface):
     tuples = get_tuple(
         postcode,
-        request_url=ciuk_request_url,
-        parse_data_from_json=ciuk_parse_data_from_json,
+        api_interface.get_request_url,
+        api_interface.parse_reponse_data,
     )
     result = writecsv(tuples, duration)
     sys.stderr.write(str(result) + "\n")
@@ -107,7 +108,13 @@ def main(arguments=None):
         loc = args.loc
     #print("Location:", loc)
 
-    starttime = findtime(loc, args.duration)
+
+    starttime = findtime(
+        loc, args.duration,
+        # TODO Choose API provider based on postcode or
+        # user option
+        API_interfaces["carbonintensitity.org.uk"],
+    )
 #    subprocess.run(
 #        [
 #            args.program,

--- a/cats/api_interface.py
+++ b/cats/api_interface.py
@@ -1,0 +1,27 @@
+from collections import namedtuple
+from datetime import datetime
+
+
+APIInterface = namedtuple('APIInterface', ['get_request_url', 'parse_response_data'])
+
+def ciuk_request_url(timestamp: datetime, postcode: str):
+    return (
+        "https://api.carbonintensity.org.uk/regional/intensity/"
+        + timestamp.strftime("%Y-%m-%dT%H:%MZ")
+        + "/fw48h/postcode/"
+        + postcode
+    )
+
+
+def ciuk_parse_response_data(response: dict):
+    return [
+        (d["from"], d["intensity"]["forecast"])
+        for d in response["data"]["data"]
+    ]
+
+API_interfaces = {
+    "carbonintensity.org.uk": APIInterface(
+        get_request_url=ciuk_request_url,
+        parse_response_data=ciuk_parse_response_data,
+        ),
+    }

--- a/tests/test_api_query.py
+++ b/tests/test_api_query.py
@@ -1,11 +1,17 @@
 import cats
+from cats.api_interface import API_interfaces
 
 def test_api_call():
     """
     This just checks the API call runs and returns a list of tuples
     """
 
-    response = cats.api_query.get_tuple('OX1')
+    api_interface = API_interfaces["carbonintensity.org.uk"]
+    response = cats.api_query.get_tuple(
+        postcode='OX1',
+        request_url=api_interface.get_request_url,
+        parse_data_from_json=api_interface.parse_response_data,
+    )
 
     assert isinstance(response, list) 
     for item in response:


### PR DESCRIPTION
It is currently assumed that carbon intensity data comes from carbonintensity.org.uk. While it is likely to remain the case for a time (until we find data sources for other countries, see #22), it didn't seem a lot of effort -- and changes -- to abstract away the API-specific bits, namely:
- Getting a URL from a postcode and job runtime duration.
- Parsing the api response into a format usable by `cats` -- currently a list of tuples.

This PR add two new arguments `request_url_fun` and `parse_response_fun` to the `parsedata.get_tuple`:

```python
def get_tuple(
    postcode: str,
    request_url_fun: Callable[[datetime, str], str],
    parse_response_fun: Callable[[dict], list[tuple[datetime, int]]],
) -> list[list[tuple[datetime, int]]]:
    """
    get carbon intensity from a web API
    # ...
   """
```

These two arguments are functions and are specified at runtime.

The list of currently supported API interfaces (i.e. the list of avilable implementations of both functions) is provided by a module `api_interface`. This module makes available a dictionary of `APIInterface` instances, which are nothing but namedtuple instances specifying both functions for a given web service.

```python
from cats.apt_interface import API_interfaces

api_interface = API_interfaces["carbonintensity.org.uk"]
tuples = get_tuple(
    postcode,
    api_interface.get_request_url,
    api_interface.parse_reponse_data,
)
```

Isolating the API-specific logic will also help should the carbonintensity.org.uk change its interface in the future. For instance the endpoint syntax or response structure.