### PR TITLE
Pass forecast data without writing csv to disk

### DIFF
--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -6,7 +6,7 @@ import re
 import yaml
 import sys
 
-from .timeseries_conversion import cat_converter  # noqa: F401
+from .timeseries_conversion import get_lowest_carbon_intensity  # noqa: F401
 from .api_query import get_tuple  # noqa: F401
 from .parsedata import writecsv, avg_carbon_intensity  # noqa: F401
 from .api_interface import API_interfaces
@@ -21,7 +21,7 @@ def findtime(postcode, duration, api_interface):
         api_interface.get_request_url,
         api_interface.parse_reponse_data,
     )
-    result = writecsv(tuples, duration)
+    result = get_lowest_carbon_intensity(data, method="windowed", duration=duration)
     sys.stderr.write(str(result) + "\n")
     return result
 

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -8,7 +8,7 @@ import sys
 
 from .timeseries_conversion import get_lowest_carbon_intensity  # noqa: F401
 from .api_query import get_tuple  # noqa: F401
-from .parsedata import writecsv, avg_carbon_intensity  # noqa: F401
+from .parsedata import avg_carbon_intensity  # noqa: F401
 from .api_interface import API_interfaces
 from .carbonFootprint import greenAlgorithmsCalculator
 

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -16,12 +16,12 @@ from .carbonFootprint import greenAlgorithmsCalculator
 
 
 def findtime(postcode, duration, api_interface):
-    tuples = get_tuple(
+    forecast = get_tuple(
         postcode,
         api_interface.get_request_url,
         api_interface.parse_reponse_data,
     )
-    result = get_lowest_carbon_intensity(data, method="windowed", duration=duration)
+    result = get_lowest_carbon_intensity(forecast, method="windowed", duration=duration)
     sys.stderr.write(str(result) + "\n")
     return result
 

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -23,7 +23,7 @@ def findtime(postcode, duration, api_interface):
     )
     result = get_lowest_carbon_intensity(forecast, method="windowed", duration=duration)
     sys.stderr.write(str(result) + "\n")
-    return result
+    return result, forecast
 
 
 def parse_arguments():
@@ -108,7 +108,7 @@ def main(arguments=None):
         loc = args.loc
     #print("Location:", loc)
 
-    best_estimate = findtime(
+    best_estimate, forecast_data = findtime(
         loc, args.duration,
         # TODO Choose API provider based on postcode or
         # user option
@@ -136,7 +136,7 @@ def main(arguments=None):
             print("ERROR: config file not found, exiting now")
             exit(1)
         now_avg_ci = avg_carbon_intensity(
-            start=datetime.now(), runtime=timedelta(args.duration)
+            data=forecast_data, start=datetime.now(), runtime=timedelta(args.duration)
         )
         estim = greenAlgorithmsCalculator(
             config=config,

--- a/cats/api_interface.py
+++ b/cats/api_interface.py
@@ -1,6 +1,8 @@
 from collections import namedtuple
 from datetime import datetime
 
+from .forecast import CarbonIntensityPointEstimate
+
 
 APIInterface = namedtuple('APIInterface', ['get_request_url', 'parse_response_data'])
 
@@ -14,8 +16,12 @@ def ciuk_request_url(timestamp: datetime, postcode: str):
 
 
 def ciuk_parse_response_data(response: dict):
+    datefmt = "%Y-%m-%dT%H:%MZ"
     return [
-        (d["from"], d["intensity"]["forecast"])
+        CarbonIntensityPointEstimate(
+            datetime=datetime.strptime(d["from"], datefmt),
+            value=d["intensity"]["forecast"],
+        )
         for d in response["data"]["data"]
     ]
 

--- a/cats/api_query.py
+++ b/cats/api_query.py
@@ -1,7 +1,6 @@
 import requests_cache
 from typing import Callable
 from datetime import datetime, timezone
-from .parsedata import writecsv
 
 
 def get_tuple(
@@ -51,4 +50,3 @@ def get_tuple(
 if __name__ == "__main__":
     # test example using Manchester as a location
     data_tuples = get_tuple("M15")
-    writecsv(data_tuples)

--- a/cats/forecast.py
+++ b/cats/forecast.py
@@ -1,6 +1,22 @@
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+
+@dataclass(order=True)
+class CarbonIntensityPointEstimate:
+    """Represents a single data point within an intensity
+    timeseries. Use order=True in order to enable comparison of class
+    instance based on the sort_index attribute.  See
+    https://peps.python.org/pep-0557
+
+    """
+    datetime: datetime
+    value: float
+
+    def __post_init__(self):
+        self.sort_index = self.value
+
+
 @dataclass(order=True)
 class CarbonIntensityAverageEstimate:
     """Represents a single data point within an *integrated* carbon
@@ -18,9 +34,9 @@ class CarbonIntensityAverageEstimate:
 
 class WindowedForecast:
 
-    def __init__(self, data: list[tuple[datetime, int]], window_size: int):
-        self.times = [row[0] for row in data]
-        self.intensities = [row[1] for row in data]
+    def __init__(self, data: list[CarbonIntensityPointEstimate], window_size: int):
+        self.times = [point.datetime for point in data]
+        self.intensities = [point.value for point in data]
         # Integration window size in number of time intervals covered
         # by the window.
         self.window_size = window_size

--- a/cats/forecast.py
+++ b/cats/forecast.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 
 
@@ -10,6 +10,7 @@ class CarbonIntensityPointEstimate:
     https://peps.python.org/pep-0557
 
     """
+    sort_index: float = field(init=False, repr=False)
     datetime: datetime
     value: float
 
@@ -24,6 +25,7 @@ class CarbonIntensityAverageEstimate:
     of class instance based on the sort_index attribute.  See
     https://peps.python.org/pep-0557
     """
+    sort_index: float = field(init=False, repr=False)
     start: datetime  # Start of the time-integration window
     end: datetime  # End of the time-integration window
     value: float

--- a/cats/parsedata.py
+++ b/cats/parsedata.py
@@ -1,76 +1,16 @@
 import bisect
 from datetime import datetime, timedelta
-from .timeseries_conversion import cat_converter, csv_loader
 
-CACHE_PATH = "./timedata.csv"
-
-
-def parsetime(datestr: str) -> datetime:
-    """parse the date string
-    param datestr: a date string from the api
-    returns: a datetime value
-    """
-    return datetime.strptime(datestr, "%Y-%m-%dT%H:%MZ")
+from .forecast import CarbonIntensityPointEstimate
 
 
-def timefromnow(time: datetime) -> tuple[int, float]:
-    """calculate the time delta between now and a timestamp
-    param time: a datetime timestamp
-    returns: tuple containing time delta in seconds and a unix timestamp
-    """
-    currenttime = datetime.now()
-    timediff = abs(currenttime - time)
-    deltaseconds = timediff.seconds
-    unixtime = time.timestamp()
-    return (deltaseconds, unixtime)
-
-
-def makedata(data: list[tuple[str, int]]) -> list[tuple[str, int, float, int]]:
-    """create csv rows from api data
-    param data: a set of tupics with start time and carbon intensity
-    returns: a list of data table rows
-    """
-    output = []
-    for d in data:
-        timestr = d[0]
-        time = parsetime(timestr)
-        [deltaseconds, unixtime] = timefromnow(time)
-        intensity = d[1]
-        output.append((timestr, deltaseconds, unixtime, intensity))
-    return output
-
-
-def csvline(parseelement: tuple[str, int, float, int]) -> str:
-    """write tuple of data row to string
-    param parseelement: a parsed data row
-    returns: a string of a data row
-    """
-    line = [str(x) for x in parseelement]
-    return ",".join(line)
-
-
-def writecsv(data: list[tuple[str, int]], duration=None) -> dict[str, int]:
-    """write api data to csv
-    param data: tuple of api output
-    returns: None
-    """
-    parseddata = makedata(data)
-    with open(CACHE_PATH, "w") as f:
-        f.write("time,deltaseconds,unix,intensity\n")
-        for d in parseddata:
-            f.write(csvline(d))
-            f.write("\n")
-    # send data to timeseries processing code and print result
-    return cat_converter(CACHE_PATH, "simple", duration)
-
-
-def avg_carbon_intensity(start: datetime, runtime: timedelta):
+def avg_carbon_intensity(data: list[CarbonIntensityPointEstimate],
+                         start: datetime, runtime: timedelta):
     """Returns the averaged carbon intensity for a job given its start
     time and runtime.
     """
-    data = csv_loader(CACHE_PATH)
-    datetimes = [row[0] for row in data]
-    intensities = [row[1] for row in data]
+    datetimes = [point.datetime for point in data]
+    intensities = [point.value for point in data]
 
     # lo is the index of the data point coming just before (or equal
     # to) the start time

--- a/cats/timeseries_conversion.py
+++ b/cats/timeseries_conversion.py
@@ -2,32 +2,7 @@
 Timeseries conversion
 """
 
-import datetime
 from .forecast import WindowedForecast
-
-
-def csv_loader(filename):
-    """
-    Load csv file without dependencies
-
-    Expected Contents:
-
-    COL1: Timestamp
-    COL2: Carbon Intensity
-    """
-    with open(filename, "r") as f:
-        data = f.readlines()
-
-    # Remove header
-    data = data[1:]
-    # Remove trailing whitespace and split by comma
-    data = [x.strip().split(",") for x in data]
-    # Convert timestamp to datetime
-    data = [
-        (datetime.datetime.strptime(x[0], "%Y-%m-%dT%H:%MZ"), float(x[3]))
-        for x in data
-    ]
-    return data
 
 
 def check_duration(size, data):
@@ -70,17 +45,8 @@ def get_lowest_carbon_intensity(data, method="simple", duration=None):
     if method == "simple":
         #  Return element with smallest 2nd value
         #  if multiple elements have the same value, return the first
-        return min(data, key=lambda x: x[1])
+        return min(data)
 
     if method == "windowed":
         num_intervals = check_duration(duration, data)
         return min(WindowedForecast(data, num_intervals))
-
-
-def cat_converter(filename, method="simple", duration=None):
-    # Load CSV
-    data = csv_loader(filename)
-    # Get lowest carbon intensity
-    lowest = get_lowest_carbon_intensity(data, method, duration=duration)
-    # Return timestamp and carbon intensity
-    return lowest

--- a/tests/test_api_query.py
+++ b/tests/test_api_query.py
@@ -1,5 +1,6 @@
 import cats
 from cats.api_interface import API_interfaces
+from cats.forecast import CarbonIntensityPointEstimate
 
 def test_api_call():
     """
@@ -13,6 +14,6 @@ def test_api_call():
         parse_data_from_json=api_interface.parse_response_data,
     )
 
-    assert isinstance(response, list) 
+    assert isinstance(response, list)
     for item in response:
-        assert isinstance(item, tuple) 
+        assert isinstance(item, CarbonIntensityPointEstimate)

--- a/tests/test_timeseries_conversion.py
+++ b/tests/test_timeseries_conversion.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import datetime
 
-import cats
+from cats.timeseries_conversion import cat_converter
 
 
 TEST_DATA = Path(__file__).parent / "carbon_intensity_24h.csv"
@@ -12,7 +12,7 @@ def test_stub():
 
 
 def test_timeseries_conversion():
-    result = cats.cat_converter(TEST_DATA)
+    result = cat_converter(TEST_DATA)
     assert result == (
         datetime.datetime(2023, 5, 5, 14, 0),
         5.0,

--- a/tests/test_windowed_forecast.py
+++ b/tests/test_windowed_forecast.py
@@ -1,13 +1,16 @@
 from datetime import datetime, timedelta
 import math
 from numpy.testing import assert_allclose
-from cats.forecast import WindowedForecast
+from cats.forecast import CarbonIntensityPointEstimate, WindowedForecast
 
 d = datetime(year=2023, month=1, day=1)
 NDATA = 200
 step = math.pi / NDATA
 DATA = [
-    (d + timedelta(minutes=i), - math.sin(i * step))
+    CarbonIntensityPointEstimate(
+        datetime=d + timedelta(minutes=i),
+        value=-1. *  math.sin(i * step),
+    )
     for i in range(NDATA)
 ]
 


### PR DESCRIPTION
Currently the best start time estimate is obtained through calling a hierarchy of functions:

`parsedata.writecsv` -> `timeseries_conversion.cat_converter` -> `timeseries_conversion.get_lowet_carbon_intensity`.

The `writecsv` function writes the forecast data on disk, only for `cat_converter` to read it straight away. I think this was originally meant to be used as a cache, but as it stands it doesn't look to me like writing forecast data to disk is useful to anything else: an API request is made at each execution of `cats`, although since #30  the request itself is cached.

This PR sends forecast data directly to `get_lowest_carbon_intensity`, which is responsible for returning the best job start time and associated average carbon intensity. This reduces complexity by removing the multiple layers between the running `__init__.py` and code that actually optimise the start time.

Instead of plain tuples, forecast data is represented as a list of `CarbonIntensityPointEstimate`.