### PR TITLE
Tidy-up command line arguments

### DIFF
--- a/cats/CI_api_interface.py
+++ b/cats/CI_api_interface.py
@@ -5,6 +5,7 @@ from .forecast import CarbonIntensityPointEstimate
 
 
 APIInterface = namedtuple('APIInterface', ['get_request_url', 'parse_response_data'])
+# TODO add a validation function to check the validity of the --location argument
 
 def ciuk_request_url(timestamp: datetime, postcode: str):
     # This transformation is specific to the CI-UK API.

--- a/cats/CI_api_interface.py
+++ b/cats/CI_api_interface.py
@@ -7,9 +7,21 @@ from .forecast import CarbonIntensityPointEstimate
 APIInterface = namedtuple('APIInterface', ['get_request_url', 'parse_response_data'])
 
 def ciuk_request_url(timestamp: datetime, postcode: str):
+    # This transformation is specific to the CI-UK API.
+    # get the time (as a datetime object) and update this to be the 'top' of
+    # the current hour or half hour in UTZ plus one minute. So a call at
+    # 17:47 BST will yield a timestamp of 16:31 UTC. This means that within
+    # any given half hour we will always use the same timestamp.
+    # As this becomes part of the URL, calls can be cached using standard HTTP
+    # caching layer.
+    if timestamp.minute > 30:
+        dt = timestamp.replace(minute=31, second=0, microsecond=0)
+    else:
+        dt = timestamp.replace(minute=1, second=0, microsecond=0)
+
     return (
         "https://api.carbonintensity.org.uk/regional/intensity/"
-        + timestamp.strftime("%Y-%m-%dT%H:%MZ")
+        + dt.strftime("%Y-%m-%dT%H:%MZ")
         + "/fw48h/postcode/"
         + postcode
     )

--- a/cats/CI_api_query.py
+++ b/cats/CI_api_query.py
@@ -13,24 +13,13 @@ def get_CI_forecast(location: str, CI_API_interface) -> list[CarbonIntensityPoin
     param location: [str] Depends on country. UK postcode (just the first section), e.g. M15.
     returns: a list of CarbonIntensityPointEstimate
     """
-    # get the time (as a datetime object) and update this to be the 'top' of
-    # the current hour or half hour in UTZ plus one minute. So a call at 
-    # 17:47 BST will yield a timestamp of 16:31 UTC. This means that within
-    # any given half hour we will always use the same timestamp. As this 
-    # becomes part of the URL, calls can be cached using standard HTTP 
-    # caching layers
-    dt = datetime.now(timezone.utc)
-    if dt.minute > 30:
-        dt = dt.replace(minute=31, second=0, microsecond=0)
-    else:
-        dt = dt.replace(minute=1, second=0, microsecond=0)
 
     # Setup a session for the API call. This uses a global HTTP cache
     # with the URL as the key. Failed attempts are not cached.
     session = requests_cache.CachedSession('cats_cache', use_temp=True)
 
     # get the carbon intensity api data
-    r = session.get(CI_API_interface.get_request_url(dt, location))
+    r = session.get(CI_API_interface.get_request_url(datetime.now(timezone.utc), location))
     data = r.json()
 
     return CI_API_interface.parse_response_data(data)

--- a/cats/CI_api_query.py
+++ b/cats/CI_api_query.py
@@ -3,25 +3,22 @@ from datetime import datetime, timezone
 
 from .forecast import CarbonIntensityPointEstimate
 
-def get_CI_forecast(postcode: str, CI_API_interface) -> list[CarbonIntensityPointEstimate]:
+def get_CI_forecast(location: str, CI_API_interface) -> list[CarbonIntensityPointEstimate]:
     """
-    get carbon intensity from carbonintensity.org.uk
+    get carbon intensity from an API
 
-    Given the postcode and an API interface, return a list of predictions of the
+    Given the location and an API interface, return a list of predictions of the
     future carbon intensity.
 
-    param postcode: UK post code (just the first section), e.g. M15
+    param location: [str] Depends on country. UK postcode (just the first section), e.g. M15.
     returns: a list of CarbonIntensityPointEstimate
     """
-    # just get the first part of the postcode, assume spaces are included
-    postcode = postcode.split()[0]
-    
     # get the time (as a datetime object) and update this to be the 'top' of
     # the current hour or half hour in UTZ plus one minute. So a call at 
     # 17:47 BST will yield a timestamp of 16:31 UTC. This means that within
     # any given half hour we will always use the same timestamp. As this 
     # becomes part of the URL, calls can be cached using standard HTTP 
-    # caching layers
+    # caching layers
     dt = datetime.now(timezone.utc)
     if dt.minute > 30:
         dt = dt.replace(minute=31, second=0, microsecond=0)
@@ -29,11 +26,11 @@ def get_CI_forecast(postcode: str, CI_API_interface) -> list[CarbonIntensityPoin
         dt = dt.replace(minute=1, second=0, microsecond=0)
 
     # Setup a session for the API call. This uses a global HTTP cache
-    # with the URL as the key. Failed attempts are not cahched.
+    # with the URL as the key. Failed attempts are not cached.
     session = requests_cache.CachedSession('cats_cache', use_temp=True)
-    # get the carbon intensity api data
 
-    r = session.get(CI_API_interface.get_request_url(dt, postcode))
+    # get the carbon intensity api data
+    r = session.get(CI_API_interface.get_request_url(dt, location))
     data = r.json()
 
     return CI_API_interface.parse_response_data(data)

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -12,6 +12,10 @@ from .parsedata import avg_carbon_intensity  # noqa: F401
 from .carbonFootprint import greenAlgorithmsCalculator
 
 def parse_arguments():
+    """
+    Parse command line arguments
+    :return: [dict] parsed arguments
+    """
     parser = ArgumentParser(prog="cats", description="A climate aware job scheduler")
 
     ### Required
@@ -44,7 +48,6 @@ def parse_arguments():
              "`cpus`: number of CPU cores, `gpus`: number of GPUs, `memory`: memory available in GB, "
              "`partition`: one of the partitions keys in `config.yml`."
     )
-
 
     return parser
 

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -127,7 +127,7 @@ def main(arguments=None):
     ################################
 
     if args.jobinfo:
-        jobinfo = validate_jobinfo(args.jobinfo, config)
+        jobinfo = validate_jobinfo(args.jobinfo, expected_partition_names=config['partitions'].keys())
 
         if not (jobinfo and config):
             sys.stderr.write("Not enough information to estimate total carbon footprint, both --jobinfo and config files are needed.\n")

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -20,24 +20,24 @@ def parse_arguments():
 
     ### Required
 
-    parser.add_argument("-d", "--duration", type=int, required=True, help="Expected duration of the job in minutes.")
+    parser.add_argument("-d", "--duration", type=int, required=True, help="[required] Expected duration of the job in minutes.")
 
     ### Optional
 
     parser.add_argument(
         "--api-carbonintensity", type=str,
-        help="[optional] which API should be used to obtain carbon intensity forecasts. Overrides `config.yml`."
+        help="Which API should be used to obtain carbon intensity forecasts. Overrides `config.yml`."
              "For now, only choice is 'carbonintensity.org.uk' (UK only) (default: 'carbonintensity.org.uk')"
     )  # Note: 'api-carbonintensity' will become 'api_carbonintensity' when parsed by argparse
     parser.add_argument(
         "-l", "--location", type=str,
-        help="[optional] location of the computing facility. For the UK, first half of a postcode (e.g. 'M15'), "
+        help="Location of the computing facility. For the UK, first half of a postcode (e.g. 'M15'), "
              "for other APIs, see doc for exact format. Overrides `config.yml`. "
              "If absent, location based in IP address is used."
     )
     parser.add_argument(
         "--config", type=str,
-        help="[optional] path to a config file, default is `config.yml` in current directory. "
+        help="Path to a config file, default is `config.yml` in current directory. "
              "Config file is required to obtain carbon footprint estimates."
              "template at https://github.com/GreenScheduler/cats/blob/main/config.yml"
     )

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -17,7 +17,6 @@ def parse_arguments():
     # Required
     parser.add_argument("-d", "--duration", type=int, required=True, help="Expected duration of the job in minutes.")
     parser.add_argument("--jobinfo")
-    parser.add_argument("--config")
 
     # Optional
     parser.add_argument(
@@ -33,6 +32,14 @@ def parse_arguments():
              "If absent, location based in IP address is used."
     )
 
+    parser.add_argument(
+        "--config", type=str,
+        help="[optional] path to a config file, default is `config.yml` in current directory. "
+             "Config file is required to obtain carbon footprint estimates."
+             "template at https://github.com/GreenScheduler/cats/blob/main/config.yml"
+    )
+
+
     return parser
 
 
@@ -40,7 +47,9 @@ def main(arguments=None):
     parser = parse_arguments()
     args = parser.parse_args(arguments)
 
-    ### Validate and clean arguments ###
+    ##################################
+    ## Validate and clean arguments ##
+    ##################################
 
     ## config file
     if args.config:
@@ -79,26 +88,26 @@ def main(arguments=None):
     ## Duration
     duration = validate_duration(args.duration)
 
-    ## Obtain CI forecast
+    ########################
+    ## Obtain CI forecast ##
+    ########################
+
     CI_API_interface = API_interfaces[choice_CI_API]
     CI_forecast = get_CI_forecast(location, CI_API_interface)
 
-    ## Find optimal start time
+    #############################
+    ## Find optimal start time ##
+    #############################
+
     best_window = get_starttime(CI_forecast, method="windowed", duration=duration)
     sys.stderr.write(str(best_window) + "\n")
 
-#    subprocess.run(
-#        [
-#            args.program,
-#            "|",
-#            "at",
-#            "-m",
-#            f"{runtime:%m%d%H%M}",
-#        ]
-#    )
-
     sys.stderr.write(f"Best job start time: {best_window.start}\n")
     print(f"{best_window.start:%Y%m%d%H%M}")  # for POSIX compatibility with at -t
+
+    ################################
+    ## Calculate carbon footprint ##
+    ################################
 
     if args.jobinfo:
         jobinfo = validate_jobinfo(args.jobinfo)

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -38,7 +38,7 @@ def parse_arguments():
     parser.add_argument(
         "--config", type=str,
         help="Path to a config file, default is `config.yml` in current directory. "
-             "Config file is required to obtain carbon footprint estimates."
+             "Config file is required to obtain carbon footprint estimates. "
              "template at https://github.com/GreenScheduler/cats/blob/main/config.yml"
     )
     parser.add_argument(

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -26,7 +26,7 @@ def parse_arguments():
 
     parser.add_argument(
         "--api-carbonintensity", type=str,
-        help="Which API should be used to obtain carbon intensity forecasts. Overrides `config.yml`."
+        help="Which API should be used to obtain carbon intensity forecasts. Overrides `config.yml`. "
              "For now, only choice is 'carbonintensity.org.uk' (UK only) (default: 'carbonintensity.org.uk')"
     )  # Note: 'api-carbonintensity' will become 'api_carbonintensity' when parsed by argparse
     parser.add_argument(

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -25,10 +25,10 @@ def parse_arguments():
     ### Optional
 
     parser.add_argument(
-        "--api-carbonintensity", type=str,
+        "-a", "--api", type=str,
         help="Which API should be used to obtain carbon intensity forecasts. Overrides `config.yml`. "
              "For now, only choice is 'carbonintensity.org.uk' (UK only) (default: 'carbonintensity.org.uk')"
-    )  # Note: 'api-carbonintensity' will become 'api_carbonintensity' when parsed by argparse
+    )
     parser.add_argument(
         "-l", "--location", type=str,
         help="Location of the computing facility. For the UK, first half of a postcode (e.g. 'M15'), "
@@ -80,10 +80,10 @@ def main(arguments=None):
     list_CI_APIs = ['carbonintensity.org.uk']
 
     choice_CI_API = 'carbonintensity.org.uk' # default value
-    if 'api-carbonintensity' in config.keys():
-        choice_CI_API = config["api-carbonintensity"]
-    if args.api_carbonintensity:
-        choice_CI_API = args.api_carbonintensity
+    if 'api' in config.keys():
+        choice_CI_API = config["api"]
+    if args.api:
+        choice_CI_API = args.api
 
     if choice_CI_API not in list_CI_APIs:
         raise ValueError(f"{choice_CI_API} is not a valid API choice, it needs to be one of {list_CI_APIs}.")

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -78,12 +78,12 @@ def main(arguments=None):
 
     ## CI API choice
     list_CI_APIs = ['carbonintensity.org.uk']
+
+    choice_CI_API = 'carbonintensity.org.uk' # default value
+    if 'api-carbonintensity' in config.keys():
+        choice_CI_API = config["api-carbonintensity"]
     if args.api_carbonintensity:
         choice_CI_API = args.api_carbonintensity
-    elif 'api-carbonintensity' in config.keys():
-        choice_CI_API = config["api-carbonintensity"]
-    else:
-        choice_CI_API = 'carbonintensity.org.uk'  # default value is UK
 
     if choice_CI_API not in list_CI_APIs:
         raise ValueError(f"{choice_CI_API} is not a valid API choice, it needs to be one of {list_CI_APIs}.")

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -14,29 +14,35 @@ from .carbonFootprint import greenAlgorithmsCalculator
 def parse_arguments():
     parser = ArgumentParser(prog="cats", description="A climate aware job scheduler")
 
-    # Required
-    parser.add_argument("-d", "--duration", type=int, required=True, help="Expected duration of the job in minutes.")
-    parser.add_argument("--jobinfo")
+    ### Required
 
-    # Optional
+    parser.add_argument("-d", "--duration", type=int, required=True, help="Expected duration of the job in minutes.")
+
+    ### Optional
+
     parser.add_argument(
         "--api-carbonintensity", type=str,
         help="[optional] which API should be used to obtain carbon intensity forecasts. Overrides `config.yml`."
              "For now, only choice is 'carbonintensity.org.uk' (UK only) (default: 'carbonintensity.org.uk')"
     )  # Note: 'api-carbonintensity' will become 'api_carbonintensity' when parsed by argparse
-
     parser.add_argument(
         "-l", "--location", type=str,
         help="[optional] location of the computing facility. For the UK, first half of a postcode (e.g. 'M15'), "
              "for other APIs, see doc for exact format. Overrides `config.yml`. "
              "If absent, location based in IP address is used."
     )
-
     parser.add_argument(
         "--config", type=str,
         help="[optional] path to a config file, default is `config.yml` in current directory. "
              "Config file is required to obtain carbon footprint estimates."
              "template at https://github.com/GreenScheduler/cats/blob/main/config.yml"
+    )
+    parser.add_argument(
+        "--jobinfo", type=str,
+        help="Resources used by the job in question, used to estimate total energy usage and carbon footprint. "
+             "E.g. 'cpus=2,gpus=0,memory=8,partition=CPU_partition'. "
+             "`cpus`: number of CPU cores, `gpus`: number of GPUs, `memory`: memory available in GB, "
+             "`partition`: one of the partitions keys in `config.yml`."
     )
 
 
@@ -110,32 +116,32 @@ def main(arguments=None):
     ################################
 
     if args.jobinfo:
-        jobinfo = validate_jobinfo(args.jobinfo)
-        if not jobinfo:
-            print("ERROR: job info parsing failed, exiting now")
-            exit(1)
-        if not config:
-            print("ERROR: config file not found, exiting now")
-            exit(1)
-        now_avg_ci = avg_carbon_intensity(
-            data=CI_forecast, start=datetime.now(), runtime=timedelta(args.duration)
-        )
-        estim = greenAlgorithmsCalculator(
-            config=config,
-            runtime=timedelta(minutes=args.duration),
-            averageBest_carbonIntensity=best_window.value, # TODO replace with real carbon intensity
-            averageNow_carbonIntensity=now_avg_ci,
-            **jobinfo,
-        ).get_footprint()
+        jobinfo = validate_jobinfo(args.jobinfo, config)
 
-        print(" -!-!- Carbon footprint estimation is a work in progress, coming soon!")
-        # Commenting these out while waiting for real carbon intensities
-        # print(f"Estimated emmissions for running job now: {estim.now}")
-        # msg = (
-        #     f"Estimated emmissions for running delayed job: {estim.best})"
-        #     f" (- {estim.savings})"
-        # )
-        # print(msg)
+        if not (jobinfo and config):
+            sys.stderr.write("Not enough information to estimate total carbon footprint, both --jobinfo and config files are needed.\n")
+        else:
+            now_avg_ci = avg_carbon_intensity(
+                data=CI_forecast, start=datetime.now(), runtime=timedelta(args.duration)
+            )
+            estim = greenAlgorithmsCalculator(
+                config=config,
+                runtime=timedelta(minutes=args.duration),
+                averageBest_carbonIntensity=best_window.value, # TODO replace with real carbon intensity
+                averageNow_carbonIntensity=now_avg_ci,
+                **jobinfo,
+            ).get_footprint()
+
+            print(" -!-!- Carbon footprint estimation is a work in progress, coming soon!")
+            # Commenting these out while waiting for real carbon intensities
+            # print(f"Estimated emmissions for running job now: {estim.now}")
+            # msg = (
+            #     f"Estimated emmissions for running delayed job: {estim.best})"
+            #     f" (- {estim.savings})"
+            # )
+            # print(msg)
+    else:
+        sys.stderr.write("Not enough information to estimate total carbon footprint, both --jobinfo and config files are needed.\n")
 
 
 if __name__ == "__main__":

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -126,11 +126,13 @@ def main(arguments=None):
     ## Calculate carbon footprint ##
     ################################
 
+    error_message = "Not enough information to estimate total carbon footprint, both --jobinfo and config files are needed.\n"
+
     if args.jobinfo:
         jobinfo = validate_jobinfo(args.jobinfo, expected_partition_names=config['partitions'].keys())
 
         if not (jobinfo and config):
-            sys.stderr.write("Not enough information to estimate total carbon footprint, both --jobinfo and config files are needed.\n")
+            sys.stderr.write(error_message)
         else:
             now_avg_ci = avg_carbon_intensity(
                 data=CI_forecast, start=datetime.now(), runtime=timedelta(args.duration)
@@ -152,7 +154,7 @@ def main(arguments=None):
             # )
             # print(msg)
     else:
-        sys.stderr.write("Not enough information to estimate total carbon footprint, both --jobinfo and config files are needed.\n")
+        sys.stderr.write(error_message)
 
 
 if __name__ == "__main__":

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -14,8 +14,8 @@ from .carbonFootprint import greenAlgorithmsCalculator
 def parse_arguments():
     parser = ArgumentParser(prog="cats", description="A climate aware job scheduler")
 
-    #parser.add_argument("program")
-    parser.add_argument("-d", "--duration", type=int, required=True)
+    # Required
+    parser.add_argument("-d", "--duration", type=int, required=True, help="Expected duration of the job in minutes.")
     parser.add_argument("--jobinfo")
     parser.add_argument("--config")
 
@@ -76,6 +76,7 @@ def main(arguments=None):
         postcode = r["postal"]
         location = validate_location(postcode, choice_CI_API)
 
+    ## Duration
     duration = validate_duration(args.duration)
 
     ## Obtain CI forecast

--- a/cats/check_clean_arguments.py
+++ b/cats/check_clean_arguments.py
@@ -45,17 +45,14 @@ def validate_jobinfo(jobinfo: str):
     return info
 
 def validate_duration(duration):
-    # make sure size is not None
-    if duration is None:
-        raise ValueError("Windowed method requires timespan to be provided")
-    # make sure size is can be converted to integer
+    # make sure it can be converted to integer
     try:
         duration_int = int(duration)
     except ValueError:
-        raise ValueError("Windowed method requires timespan to be an integer or float")
-    # make sure size is positive
+        raise ValueError("--duration needs to be an integer or float (number of minutes)")
+    # make sure it's positive
     if duration_int <= 0:
-        raise ValueError("Windowed method requires timespan to be positive")
+        raise ValueError("--duration needs to be positive (number of minutes)")
 
     return duration_int
 

--- a/cats/check_clean_arguments.py
+++ b/cats/check_clean_arguments.py
@@ -1,7 +1,7 @@
 import re
 import sys
 
-def validate_jobinfo(jobinfo: str, config):
+def validate_jobinfo(jobinfo: str, expected_partition_names):
     """Parses a string of job info keys in the form
 
     partition=CPU_partition,memory=8,ncpus=8,ngpus=0
@@ -29,9 +29,8 @@ def validate_jobinfo(jobinfo: str, config):
         return {}
 
     # Validate partition value
-    expected_partition_values = config['partitions'].keys()
-    if info["partition"] not in expected_partition_values:
-        sys.stderr.write("ERROR: job info key 'partition' should be one of {expected_partition_values}. Typo?\n")
+    if info["partition"] not in expected_partition_names:
+        sys.stderr.write(f"ERROR: job info key 'partition' should be one of {expected_partition_names}. Typo?\n")
         return {}
 
     # check that `cpus`, `gpus` and `memory` are numeric and convert to int

--- a/cats/check_clean_arguments.py
+++ b/cats/check_clean_arguments.py
@@ -58,3 +58,16 @@ def validate_duration(duration):
         raise ValueError("Windowed method requires timespan to be positive")
 
     return duration_int
+
+def validate_location(location, choice_CI_API):
+    if choice_CI_API == 'carbonintensity.org.uk':
+        # in case the long format of the postcode is provided:
+        loc_cleaned = location.split()[0]
+
+        # check that it's between 2 and 4 characters long
+        # TODO Check that it's a valid postcode for the API/country of interest
+        if (len(loc_cleaned) < 2) or (len(loc_cleaned) > 4):
+            raise ValueError(f"{location} is an invalid UK postcode. Only the first part of the postcode is expected (e.g. M15).")
+    else:
+        loc_cleaned = location
+    return loc_cleaned

--- a/config.yml
+++ b/config.yml
@@ -8,6 +8,7 @@
 ---
 cluster_name: "CW23"
 postcode: "EH8 9BT"
+api-carbonintensity: carbonintensity.org.uk
 PUE: 1.20 # > 1
 partitions:
   CPU_partition:

--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,7 @@
 ---
 cluster_name: "CW23"
 location: "EH8"
-api-carbonintensity: carbonintensity.org.uk
+api: carbonintensity.org.uk
 PUE: 1.20 # > 1
 partitions:
   CPU_partition:

--- a/config.yml
+++ b/config.yml
@@ -3,7 +3,7 @@
 ##
 ## Settings for fictive CW23
 ##
-## Updated: 04/05/2023
+## Updated: 12/07/2023
 
 ---
 cluster_name: "CW23"

--- a/config.yml
+++ b/config.yml
@@ -7,7 +7,7 @@
 
 ---
 cluster_name: "CW23"
-postcode: "EH8 9BT"
+location: "EH8"
 api-carbonintensity: carbonintensity.org.uk
 PUE: 1.20 # > 1
 partitions:


### PR DESCRIPTION
This is a quick tidy-up of the different command line arguments available and their validation. The goal is to add hints and improve clarity for users, while also being consistent with the current project structure. 

- Drafted "help" text for all arguments (which would show with `-h` menu
- Moved the validation/cleaning of the location to `check_clean_arguments.py` 
- Added an argument to choose a CI API (or in the future, pass their own)
- small clean-up of the `validate_duration` function 
- small clean-up of `validate_jobinfo`
- Print out the values of different arguments (location, config used, CI API used etc.) to `stderr` to confirm values used to users (and simplify debugging for us!)
- Moved datetime 30min standardisation to the interface instead of the query (as this is interface specific, and is linked to the 30min window in the UK) -> I noticed I missed that in the previous PR