### PR TITLE
Deploy documentation automatically from `main`

### DIFF
--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -1,0 +1,21 @@
+name: Build and deploy docs
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - run: |
+        pip install -r docs/docs-requirements.txt
+    - name: Build sphinx docs
+      run: make -C docs html
+    - name: Deploy sphinx docs
+      run: |
+        git config user.name 'github-action'
+        git config user.email 'github-action'
+        ghp-import -m 'Update sphinx docs' --push --no-history \
+          --branch gh-pages --no-jekyll --force docs/build/html

--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3

--- a/docs/docs-requirements.txt
+++ b/docs/docs-requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+ghp-import
+renku-sphinx-theme
+sphinx_copybutton


### PR DESCRIPTION
This add a GitHub workflow to build the documentation website from sources in `docs/`. The built website is pushed to the `gh-pages` branch which can be used by GitHub to deploy the site.

In practice the documentation will be built and deployed each time commits are added to the `main`branch.

Somebody with elevated privileges (I think one of @andreww @c-martinez @tonymugen or @Llannelongue )should go into the repo settings and enable GitHub _Pages_ to be deployed from the root of the `gh-pages` branch. It's also important to check that Actions have read/write permissions (from the `Actions` section in the settings page).