### PR TITLE
Account for job start/end time not exactly matching forecast data points

### DIFF
--- a/cats/forecast.py
+++ b/cats/forecast.py
@@ -44,22 +44,22 @@ class WindowedForecast:
             start: datetime,
     ):
         self.data = data
+        self.data_stepsize = data[1].datetime - data[0].datetime
+        self.start = start
+        # TODO: Expect duration as a timedelta directly
         self.end = start + timedelta(minutes=duration)
         self.ndata = bisect_left(data, self.end, key=lambda x: x.datetime) + 1
-        self.start = start
-        self.data_stepsize = data[1].datetime - data[0].datetime
-        # TODO: Expect duration as a timedelta directly
-        self.duration = timedelta(minutes=duration)
 
     def __getitem__(self, index: int) -> CarbonIntensityAverageEstimate:
         """Return the average of timeseries data from index over the
         window size.  Data points are integrated using the trapeziodal
         rule, that is assuming that forecast data points are joined
-        with a straight line. Integral value between two points is the
-        intensity value at the midpoint times the duration between the
-        two points.  This duration is assumed to be unity and the
-        average is computed by dividing the total integral value by
-        the number of intervals.
+        with a straight line.
+
+        Integral value between two points is the intensity value at
+        the midpoint times the duration between the two points.  This
+        duration is assumed to be unity and the average is computed by
+        dividing the total integral value by the number of intervals.
         """
         midpt = [
             0.5 * (a.value + b.value)
@@ -78,7 +78,7 @@ class WindowedForecast:
         i = self.interp(self.data[index], self.data[index + 1], when=start)
         midpt[0] = 0.5 * (i + self.data[index + 1].value)
 
-        end = self.start + index * self.data_stepsize + self.duration
+        end = self.end + index * self.data_stepsize
         i = self.interp(
             self.data[index + self.ndata - 2],
             self.data[index + self.ndata - 1],

--- a/cats/forecast.py
+++ b/cats/forecast.py
@@ -1,3 +1,4 @@
+from math import ceil
 from dataclasses import dataclass, field
 from datetime import datetime
 
@@ -36,12 +37,20 @@ class CarbonIntensityAverageEstimate:
 
 class WindowedForecast:
 
-    def __init__(self, data: list[CarbonIntensityPointEstimate], window_size: int):
+    def __init__(
+            self,
+            data: list[CarbonIntensityPointEstimate],
+            duration: int,  # in minutes
+            start: datetime,
+    ):
         self.times = [point.datetime for point in data]
         self.intensities = [point.value for point in data]
         # Integration window size in number of time intervals covered
         # by the window.
-        self.window_size = window_size
+        data_stepsize = (
+            data[1].datetime - data[0].datetime
+        ).total_seconds() / 60
+        self.window_size = ceil(duration / data_stepsize)
 
     def __getitem__(self, index: int) -> CarbonIntensityAverageEstimate:
         """Return the average of timeseries data from index over the

--- a/cats/forecast.py
+++ b/cats/forecast.py
@@ -1,5 +1,4 @@
 from bisect import bisect_left
-from math import ceil
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 

--- a/cats/forecast.py
+++ b/cats/forecast.py
@@ -52,6 +52,19 @@ class WindowedForecast:
         ).total_seconds() / 60
         self.window_size = ceil(duration / data_stepsize)
 
+    @staticmethod
+    def interp(
+            p1: CarbonIntensityPointEstimate,
+            p2: CarbonIntensityPointEstimate,
+            p: datetime
+    ):
+        timestep = (p2.datetime - p1.datetime).total_seconds()
+
+        slope = (p2.value - p1.value) / timestep
+        offset = (p - p1.datetime).total_seconds()
+        # import pdb; pdb.set_trace()
+        return p1.value + slope * offset  # Value at t = start
+
     def __getitem__(self, index: int) -> CarbonIntensityAverageEstimate:
         """Return the average of timeseries data from index over the
         window size.  Data points are integrated using the trapeziodal

--- a/cats/forecast.py
+++ b/cats/forecast.py
@@ -52,23 +52,6 @@ class WindowedForecast:
         # TODO: Expect duration as a timedelta directly
         self.duration = timedelta(minutes=duration)
 
-    @staticmethod
-    def interp(
-            p1: CarbonIntensityPointEstimate,
-            p2: CarbonIntensityPointEstimate,
-            when: datetime
-    ):
-        """Return value of carbon intensity at a time between data
-        points, assuming points are joined by a straight line (linear
-        interpolation).
-        """
-        timestep = (p2.datetime - p1.datetime).total_seconds()
-
-        slope = (p2.value - p1.value) / timestep
-        offset = (when - p1.datetime).total_seconds()
-        # import pdb; pdb.set_trace()
-        return p1.value + slope * offset  # Value at t = start
-
     def __getitem__(self, index: int) -> CarbonIntensityAverageEstimate:
         """Return the average of timeseries data from index over the
         window size.  Data points are integrated using the trapeziodal
@@ -109,6 +92,23 @@ class WindowedForecast:
             end=end,
             value=sum(midpt) / (self.ndata - 1),
         )
+
+    @staticmethod
+    def interp(
+            p1: CarbonIntensityPointEstimate,
+            p2: CarbonIntensityPointEstimate,
+            when: datetime
+    ):
+        """Return value of carbon intensity at a time between data
+        points, assuming points are joined by a straight line (linear
+        interpolation).
+        """
+        timestep = (p2.datetime - p1.datetime).total_seconds()
+
+        slope = (p2.value - p1.value) / timestep
+        offset = (when - p1.datetime).total_seconds()
+        # import pdb; pdb.set_trace()
+        return p1.value + slope * offset  # Value at t = start
 
     def __iter__(self):
         for index in range(self.__len__()):

--- a/cats/forecast.py
+++ b/cats/forecast.py
@@ -58,6 +58,10 @@ class WindowedForecast:
             p2: CarbonIntensityPointEstimate,
             when: datetime
     ):
+        """Return value of carbon intensity at a time between data
+        points, assuming points are joined by a straight line (linear
+        interpolation).
+        """
         timestep = (p2.datetime - p1.datetime).total_seconds()
 
         slope = (p2.value - p1.value) / timestep

--- a/cats/optimise_starttime.py
+++ b/cats/optimise_starttime.py
@@ -1,4 +1,4 @@
-from math import ceil
+from datetime import datetime
 from .forecast import WindowedForecast
 
 
@@ -28,11 +28,5 @@ def get_avg_estimates(data, method="simple", duration=None):
 
     if method == "windowed":
         # get length of interval between timestamps
-        interval = (
-            data[1].datetime - data[0].datetime
-        ).total_seconds() / 60
-        wf = WindowedForecast(
-            data=data,
-            window_size=ceil(duration / interval)
-        )
+        wf = WindowedForecast(data, duration, start=datetime.now())
         return wf[0], min(wf)

--- a/tests/test_windowed_forecast.py
+++ b/tests/test_windowed_forecast.py
@@ -24,7 +24,7 @@ TEST_DATA = Path(__file__).parent / "carbon_intensity_24h.csv"
 
 def test_has_right_length():
     window_size = 160  # In number of time intervals
-    wf = WindowedForecast(DATA, window_size)
+    wf = WindowedForecast(DATA, window_size, start=DATA[0].datetime)
 
     # Expecting (200 - 160 - 1) (39) data points in the time
     # integrated timeseries.
@@ -39,7 +39,7 @@ def test_values():
     # a step size `step` small compared the the integration window
 
     window_size = 160
-    wf = WindowedForecast(DATA, window_size)
+    wf = WindowedForecast(DATA, window_size, start=DATA[0].datetime)
     expected = [
 
         math.cos((i + window_size) * step) - math.cos(i * step)
@@ -68,7 +68,9 @@ def test_minimise_average():
         ]
 
         window_size = 6
-        result = min(WindowedForecast(data, window_size))
+        # Data points separated by 30 minutes intervals
+        duration = window_size * 30
+        result = min(WindowedForecast(data, duration, start=data[0].datetime))
 
         # Intensity point estimates over best runtime period
         v = [10, 8, 7, 7, 5, 8, 8]
@@ -95,7 +97,9 @@ def test_average_intensity_now():
         ]
 
         window_size = 11
-        result = WindowedForecast(data, window_size)[0]
+        # Data points separated by 30 minutes intervals
+        duration = window_size * 30
+        result = WindowedForecast(data, duration, start=data[0].datetime)[0]
 
         # Intensity point estimates over best runtime period
         v = [p.value for p in data[:window_size + 1]]


### PR DESCRIPTION
Currently, the average carbon intensity for a job is estimated over a time interval spanning $N + 1$ data points, where $N$ is the `ceil` of the ratio between the job duration and the timestep between data points.  Moreover, cats approximates the job start time as the time of the first available data points. For carbonintensity.org.uk, this the previous top of the hour, or half hour. 

**example**:
current time is 12:48 and my job is 194 minutes long. The job start time will be approximated as 12:30, and the job duration will be approximation as $210min = 7 \times 30min$ where $30min$ is the interval between two data points.

The approach followed in the PR is similar to changes included in #43 , but the implementation fits within the current structure by only enhancing the `WindowedForecast` class. These changes are covered by a new test `test_average_intensity_with_offset`.

**implementation**:
The average carbon intensity over a given time window is estimated by summing the intensity values at the midpoints between each consecutive data points in the window. The first midpoint (`midpt[0]`) is overidden to account for the fact that the first point (used to compute `midpt[0]`) should be located at the job start time. The corresponding intensity value is interpolated between the first and second data point. Similarly, the last midpoint (`midpt[-1]`) is overidden to account for the fast that the last point should be located at the job end time. The corresponding intensity value is interpolated between the penultimate and last data points in the window.