### PR TITLE
Make sure we respect local system time

### DIFF
--- a/cats/CI_api_interface.py
+++ b/cats/CI_api_interface.py
@@ -1,6 +1,7 @@
 import sys
 from collections import namedtuple
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from .forecast import CarbonIntensityPointEstimate
 
@@ -63,9 +64,13 @@ def ciuk_parse_response_data(response: dict):
         raise InvalidLocationError
 
     datefmt = "%Y-%m-%dT%H:%MZ"
+    # The "Z" at the end of the format string indicates UTC,
+    # however, strptime does not know how to parse this, so we 
+    # need to add tzinfo data.
+    utc = ZoneInfo('UTC')
     return [
         CarbonIntensityPointEstimate(
-            datetime=datetime.strptime(d["from"], datefmt),
+            datetime=datetime.strptime(d["from"], datefmt).replace(tzinfo=utc),
             value=d["intensity"]["forecast"],
         )
         for d in response["data"]["data"]

--- a/cats/optimise_starttime.py
+++ b/cats/optimise_starttime.py
@@ -16,5 +16,10 @@ def get_avg_estimates(data, duration=None):
     #     raise ValueError(
     #         "Windowed method timespan cannot be greater than the cached timespan"
     #     )
-    wf = WindowedForecast(data, duration, start=datetime.now())
+    # NB: datetime.now().astimezone() gives us a timezone aware datetime object
+    # in the current system timezone. The resulting start time from the forecast
+    # works in terms of this timezone (even if the data is in another timezone)
+    # so we end up with something in system time if data is in utc and system
+    # time is in bst (for example)
+    wf = WindowedForecast(data, duration, start=datetime.now().astimezone())
     return wf[0], min(wf)

--- a/tests/test_api_query.py
+++ b/tests/test_api_query.py
@@ -7,7 +7,9 @@ from cats.forecast import CarbonIntensityPointEstimate
 def test_api_call():
     """
     This just checks the API call runs and returns a list of point estimates
-    and confirms that datetime objects are timezone aware
+
+    Also confirms that datetime objects are timezone aware, as per
+    https://docs.python.org/3/library/datetime.html#determining-if-an-object-is-aware-or-naive
     """
 
     api_interface = API_interfaces["carbonintensity.org.uk"]

--- a/tests/test_api_query.py
+++ b/tests/test_api_query.py
@@ -6,7 +6,8 @@ from cats.forecast import CarbonIntensityPointEstimate
 
 def test_api_call():
     """
-    This just checks the API call runs and returns a list of tuples
+    This just checks the API call runs and returns a list of point estimates
+    and confirms that datetime objects are timezone aware
     """
 
     api_interface = API_interfaces["carbonintensity.org.uk"]
@@ -15,6 +16,8 @@ def test_api_call():
     assert isinstance(response, list)
     for item in response:
         assert isinstance(item, CarbonIntensityPointEstimate)
+        assert ((item.datetime.tzinfo is not None) and
+                (item.datetime.tzinfo.utcoffset(item.datetime) is not None))
 
 def test_bad_postcode():
     api_interface = API_interfaces["carbonintensity.org.uk"]
@@ -24,3 +27,4 @@ def test_bad_postcode():
 
     with pytest.raises(InvalidLocationError):
         response = cats.CI_api_query.get_CI_forecast('A', api_interface)
+

--- a/tests/test_windowed_forecast.py
+++ b/tests/test_windowed_forecast.py
@@ -212,7 +212,8 @@ def test_average_intensity_with_offset_long_job():
         duration = 194  # in minutes
         # First available data point is for 12:30 but the job
         # starts 18 minutes later.
-        job_start = datetime.fromisoformat("2023-05-04T12:48+00:00")
+        # Start time in BST
+        job_start = datetime.fromisoformat("2023-05-04T13:48+01:00")
         result = WindowedForecast(data, duration, start=job_start)[2]
 
         # First and last element in v are interpolated intensity value.
@@ -229,6 +230,8 @@ def test_average_intensity_with_offset_long_job():
             ) / duration
         )
         assert (result == expected)
+        assert (result.start.tzinfo == expected.start.tzinfo)
+        assert (result.end.tzinfo == expected.end.tzinfo)
 
 def test_average_intensity_with_offset_short_job():
     # Case where job is short: start and end time fall between two


### PR DESCRIPTION
This (draft) pull request makes sure we keep track of any differences in timezone between system time (e.g. used for `at`) and the time zone returned by our datasource. To do this, we need to:

- [x] Make sure the datetime objects in the CarbonIntensityPointEstimate are timezone aware
- [x] Set the correct timezone on these objects
- [x] Make sure the timezone is still set for the calculated start time
- [x] Convert to the correct system time when we output a start time
- [x] Make sure our other reported dates and times are correct with respect to timezones

With a little luck, the actual calculation will 'just work'. We should check this. 

This addresses #21 