### PR TITLE
Minor documentation updates for consistency and clarity

### DIFF
--- a/cats/CI_api_query.py
+++ b/cats/CI_api_query.py
@@ -5,7 +5,7 @@ from .forecast import CarbonIntensityPointEstimate
 
 def get_CI_forecast(location: str, CI_API_interface) -> list[CarbonIntensityPointEstimate]:
     """
-    get carbon intensity from an API
+    Get carbon intensity from an API
 
     Given the location and an API interface, return a list of predictions of the
     future carbon intensity.

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -45,9 +45,10 @@ def parse_arguments():
     parser.add_argument(
         "--jobinfo", type=str,
         help="Resources used by the job in question, used to estimate total energy usage and carbon footprint. "
-             "E.g. `cpus=2,gpus=0,memory=8,partition=CPU_partition`. Valid components are: "
-             "`cpus`: number of CPU cores, `gpus`: number of GPUs, `memory`: memory available in GB, "
-             "`partition`: one of the partitions keys given in `config.yml`."
+             "E.g. `cpus=2,gpus=0,memory=8,partition=CPU_partition`. Valid components are "
+             "`cpus`: number of CPU cores; `gpus`: number of GPUs; `memory`: memory available in GB; "
+             "`partition`: one of the partitions keys given in `config.yml`. "
+             "Default: if absent, the total carbon footprint is not estimated."
     )
 
     return parser

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -19,33 +19,35 @@ def parse_arguments():
 
     ### Required
 
-    parser.add_argument("-d", "--duration", type=int, required=True, help="[required] Expected duration of the job in minutes.")
+    parser.add_argument(
+        "-d", "--duration", type=int, required=True, help="[required] Expected duration of the job in minutes.")
 
     ### Optional
 
     parser.add_argument(
         "-a", "--api", type=str,
-        help="Which API should be used to obtain carbon intensity forecasts. Overrides `config.yml`. "
-             "For now, only choice is 'carbonintensity.org.uk' (UK only) (default: 'carbonintensity.org.uk')"
+        help="API to use to obtain carbon intensity forecasts. Overrides `config.yml`. "
+             "For now, only choice is `carbonintensity.org.uk` (hence UK only forecasts). "
+             "Default: `carbonintensity.org.uk`."
     )
     parser.add_argument(
         "-l", "--location", type=str,
-        help="Location of the computing facility. For the UK, first half of a postcode (e.g. 'M15'), "
-             "for other APIs, see doc for exact format. Overrides `config.yml`. "
-             "If absent, location based in IP address is used."
+        help="Location of the computing facility. For the UK, first half of a postcode (e.g. `M15`), "
+             "for other APIs, see documentation for exact format. Overrides `config.yml`. "
+             "Default: if absent, location based in IP address is used."
     )
     parser.add_argument(
         "--config", type=str,
-        help="Path to a config file, default is `config.yml` in current directory. "
-             "Config file is required to obtain carbon footprint estimates. "
-             "template at https://github.com/GreenScheduler/cats/blob/main/config.yml"
+        help="Path to a configuration file. The file is required to obtain carbon footprint estimates. "
+             "Default: `config.yml` in current directory."
+             "Template found at https://github.com/GreenScheduler/cats/blob/main/config.yml."
     )
     parser.add_argument(
         "--jobinfo", type=str,
         help="Resources used by the job in question, used to estimate total energy usage and carbon footprint. "
-             "E.g. 'cpus=2,gpus=0,memory=8,partition=CPU_partition'. "
+             "E.g. `cpus=2,gpus=0,memory=8,partition=CPU_partition`. Valid components are: "
              "`cpus`: number of CPU cores, `gpus`: number of GPUs, `memory`: memory available in GB, "
-             "`partition`: one of the partitions keys in `config.yml`."
+             "`partition`: one of the partitions keys given in `config.yml`."
     )
 
     return parser

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,15 +77,9 @@ The HTML pages are in build/html.
 
 ### Requirements
 
-An environment to build the documentation will need the following libraries
-installed to work and produce the right output:
-
-* Python (version compatible with CATS);
-* the latest version of CATS (ensure it is the *latest* on the `main`
-  branch, etc., or the API reference generated will be out-of-date);
-* [Sphinx](https://www.sphinx-doc.org/);
-* the [Sphinx theme 'renku'](https://github.com/SwissDataScienceCenter/renku-sphinx-theme);
-* the ['sphinx_copybutton' extension](https://sphinx-copybutton.readthedocs.io/en/latest/).
+An environment to build the documentation will need certain libraries
+installed to work and produce the right output. The
+``docs-requirements.txt`` file in this directory lists those libraries.
 
 
 #### Environment for building


### PR DESCRIPTION
Quick one to make some minor formatting updates, mostly for the command-line help descriptions (I went in to update the documentation README and thought I should include these updates), namely:

* instead of listing the documentation build requirements in the README, pointing to the new `docs-requirements.txt` file created in #60 so we don't have two equivalent lists to keep in sync;
* being more consistent in the command-line descriptions by, e.g., using only single quotes around all keywords (means the generated CLI reference emphasises them via italics but avoiding double quotes which will clutter the terminal `--help` output) and listing defaults at the end;
* adding default information for `--jobinfo` which was missing before, to be explicit and clear;
* capitalising the first word from one docstring which was inconsistent with the others coming through in the API reference.
