### PR TITLE
Move processing of cli args and config file to separate module

### DIFF
--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -14,7 +14,7 @@ from typing import Optional
 from .configure import configure
 from .check_clean_arguments import validate_jobinfo
 from .optimise_starttime import get_avg_estimates  # noqa: F401
-from .CI_api_interface import API_interfaces, InvalidLocationError
+from .CI_api_interface import InvalidLocationError
 from .CI_api_query import get_CI_forecast  # noqa: F401
 from .forecast import CarbonIntensityAverageEstimate
 from .optimise_starttime import get_avg_estimates  # noqa: F401

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -12,8 +12,8 @@ from datetime import timedelta
 from typing import Optional
 
 from .configure import configure
+from .carbonFootprint import Estimates, greenAlgorithmsCalculator
 from .check_clean_arguments import validate_jobinfo
-from .optimise_starttime import get_avg_estimates  # noqa: F401
 from .CI_api_interface import InvalidLocationError
 from .CI_api_query import get_CI_forecast  # noqa: F401
 from .forecast import CarbonIntensityAverageEstimate

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -147,7 +147,6 @@ def parse_arguments():
 class CATSOutput:
     """Carbon Aware Task Scheduler output"""
 
-    carbonIntensityAPI: str
     carbonIntensityNow: CarbonIntensityAverageEstimate
     carbonIntensityOptimal: CarbonIntensityAverageEstimate
     location: str

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -201,23 +201,7 @@ def main(arguments=None):
     ## Validate and clean arguments ##
     ##################################
 
-    config = configure(args)
-
-
-    ## CI API choice
-    list_CI_APIs = ["carbonintensity.org.uk"]
-
-    choice_CI_API = "carbonintensity.org.uk"  # default value
-    if "api" in config.keys():
-        choice_CI_API = config["api"]
-    if args.api:
-        choice_CI_API = args.api
-
-    if choice_CI_API not in list_CI_APIs:
-        raise ValueError(
-            f"{choice_CI_API} is not a valid API choice, it needs to be one of {list_CI_APIs}."
-        )
-    logging.info(f"Using {choice_CI_API} for carbon intensity forecasts\n")
+    config, CI_API_interface = configure(args)
 
     ## Location
     if args.location:
@@ -241,7 +225,6 @@ def main(arguments=None):
     ## Obtain CI forecast ##
     ########################
 
-    CI_API_interface = API_interfaces[choice_CI_API]
     try:
         CI_forecast = get_CI_forecast(location, CI_API_interface)
     except InvalidLocationError:

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -1,4 +1,8 @@
 import dataclasses
+import logging
+import yaml
+import sys
+import subprocess
 import json
 import logging
 import subprocess
@@ -204,19 +208,6 @@ def main(arguments=None):
     config, CI_API_interface = configure(args)
 
     ## Location
-    if args.location:
-        location = args.location
-        logging.info(f"Using location provided: {location}")
-    elif "location" in config.keys():
-        location = config["location"]
-        logging.info(f"Using location from config file: {location}")
-    else:
-        r = requests.get("https://ipapi.co/json").json()
-        postcode = r["postal"]
-        location = postcode
-        logging.warning(
-            f"location not provided. Estimating location from IP address: {location}."
-        )
 
     ## Duration
     duration = validate_duration(args.duration)

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -7,11 +7,9 @@ from argparse import ArgumentParser
 from datetime import timedelta
 from typing import Optional
 
-import requests
-import yaml
-
-from .carbonFootprint import Estimates, greenAlgorithmsCalculator
-from .check_clean_arguments import validate_duration, validate_jobinfo
+from .configure import configure
+from .check_clean_arguments import validate_jobinfo, validate_duration
+from .optimise_starttime import get_avg_estimates  # noqa: F401
 from .CI_api_interface import API_interfaces, InvalidLocationError
 from .CI_api_query import get_CI_forecast  # noqa: F401
 from .forecast import CarbonIntensityAverageEstimate
@@ -203,21 +201,8 @@ def main(arguments=None):
     ## Validate and clean arguments ##
     ##################################
 
-    ## config file
-    if args.config:
-        # if path to config file provided, it is used
-        with open(args.config, "r") as f:
-            config = yaml.safe_load(f)
-        logging.info(f"Using provided config file: {args.config}\n")
-    else:
-        # if no path provided, look for `config.yml` in current directory
-        try:
-            with open("config.yml", "r") as f:
-                config = yaml.safe_load(f)
-            logging.info("Using config.yml found in current directory\n")
-        except FileNotFoundError:
-            config = {}
-            logging.warning("config file not found")
+    config = configure(args)
+
 
     ## CI API choice
     list_CI_APIs = ["carbonintensity.org.uk"]

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -11,7 +11,7 @@ from .carbonFootprint import Estimates, greenAlgorithmsCalculator
 from .check_clean_arguments import validate_jobinfo
 from .CI_api_interface import InvalidLocationError
 from .CI_api_query import get_CI_forecast  # noqa: F401
-from .configure import configure
+from .configure import get_runtime_config
 from .forecast import CarbonIntensityAverageEstimate
 from .optimise_starttime import get_avg_estimates  # noqa: F401
 
@@ -195,7 +195,7 @@ def main(arguments=None):
             "      specify the scheduler with the -s or --scheduler option"
         )
         sys.exit(1)
-    config, CI_API_interface, location, duration = configure(args)
+    config, CI_API_interface, location, duration = get_runtime_config(args)
 
     ########################
     ## Obtain CI forecast ##

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -12,7 +12,7 @@ from datetime import timedelta
 from typing import Optional
 
 from .configure import configure
-from .check_clean_arguments import validate_jobinfo, validate_duration
+from .check_clean_arguments import validate_jobinfo
 from .optimise_starttime import get_avg_estimates  # noqa: F401
 from .CI_api_interface import API_interfaces, InvalidLocationError
 from .CI_api_query import get_CI_forecast  # noqa: F401
@@ -200,17 +200,7 @@ def main(arguments=None):
             "      specify the scheduler with the -s or --scheduler option"
         )
         sys.exit(1)
-
-    ##################################
-    ## Validate and clean arguments ##
-    ##################################
-
-    config, CI_API_interface = configure(args)
-
-    ## Location
-
-    ## Duration
-    duration = validate_duration(args.duration)
+    config, CI_API_interface, location, duration = configure(args)
 
     ########################
     ## Obtain CI forecast ##

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -1,8 +1,4 @@
 import dataclasses
-import logging
-import yaml
-import sys
-import subprocess
 import json
 import logging
 import subprocess
@@ -11,11 +7,11 @@ from argparse import ArgumentParser
 from datetime import timedelta
 from typing import Optional
 
-from .configure import configure
 from .carbonFootprint import Estimates, greenAlgorithmsCalculator
 from .check_clean_arguments import validate_jobinfo
 from .CI_api_interface import InvalidLocationError
 from .CI_api_query import get_CI_forecast  # noqa: F401
+from .configure import configure
 from .forecast import CarbonIntensityAverageEstimate
 from .optimise_starttime import get_avg_estimates  # noqa: F401
 
@@ -222,7 +218,7 @@ def main(arguments=None):
     # Find best possible average carbon intensity, along
     # with corresponding job start time.
     now_avg, best_avg = get_avg_estimates(CI_forecast, duration=duration)
-    output = CATSOutput(choice_CI_API, now_avg, best_avg, location, "GBR")
+    output = CATSOutput(now_avg, best_avg, location, "GBR")
 
     ################################
     ## Calculate carbon footprint ##

--- a/cats/check_clean_arguments.py
+++ b/cats/check_clean_arguments.py
@@ -45,18 +45,3 @@ def validate_jobinfo(jobinfo: str, expected_partition_names):
             return {}
 
     return info
-
-
-def validate_duration(duration):
-    # make sure it can be converted to integer
-    try:
-        duration_int = int(duration)
-    except ValueError:
-        raise ValueError(
-            "--duration needs to be an integer or float (number of minutes)"
-        )
-    # make sure it's positive
-    if duration_int <= 0:
-        raise ValueError("--duration needs to be positive (number of minutes)")
-
-    return duration_int

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import yaml
+import requests
 
 from .CI_api_interface import API_interfaces, APIInterface
 
@@ -18,8 +19,9 @@ from .CI_api_interface import API_interfaces, APIInterface
 def configure(args):
     configmapping = config_from_file(configpath=args.config)
     CI_API_interface = CI_API_from_config_or_args(args, configmapping)
+    location = get_location_from_config_or_args(args, configmapping)
 
-    return configmapping, CI_API_interface
+    return configmapping, CI_API_interface, location
 
 
 def config_from_file(configpath = "") -> Mapping[str, Any]:
@@ -55,3 +57,19 @@ def CI_API_from_config_or_args(args, config) -> APIInterface:
             f"Error: {api} is not a valid API choice. It must be one of "
             "\n".join(API_interfaces.keys())
         )
+
+
+def get_location_from_config_or_args(args, config) -> str:
+    if args.location:
+        logging.info(f"Using location provided: {location}")
+        return args.location
+    if "location" in config.keys():
+        logging.info(f"Using location from config file: {location}")
+        return config["location"]
+
+    logging.warning(
+        "location not provided. Estimating location from IP address: "
+        f"{location}."
+    )
+    r = requests.get("https://ipapi.co/json").json()
+    return r["postal"]

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -72,15 +72,18 @@ def CI_API_from_config_or_args(args, config) -> APIInterface:
 
 def get_location_from_config_or_args(args, config) -> str:
     if args.location:
+        location = args.location
         logging.info(f"Using location provided: {location}")
-        return args.location
+        return location
     if "location" in config.keys():
+        location = config["location"]
         logging.info(f"Using location from config file: {location}")
-        return config["location"]
+        return location
 
+    r = requests.get("https://ipapi.co/json").json()
+    location = r["postal"]
     logging.warning(
         "location not provided. Estimating location from IP address: "
         f"{location}."
     )
-    r = requests.get("https://ipapi.co/json").json()
-    return r["postal"]
+    return location

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -12,10 +12,14 @@ from typing import Any
 
 import yaml
 
+from .CI_api_interface import API_interfaces, APIInterface
+
 
 def configure(args):
     configmapping = config_from_file(configpath=args.config)
-    return configmapping
+    CI_API_interface = CI_API_from_config_or_args(args, configmapping)
+
+    return configmapping, CI_API_interface
 
 
 def config_from_file(configpath = "") -> Mapping[str, Any]:
@@ -33,3 +37,21 @@ def config_from_file(configpath = "") -> Mapping[str, Any]:
         except FileNotFoundError:
             logging.warning("config file not found")
             return {}
+
+
+def CI_API_from_config_or_args(args, config) -> APIInterface:
+    try:
+        api = args.api if args.api else config["api"]
+    except KeyError:
+        api = 'carbonintensity.org.uk'  # default value
+        logging.warning(
+            "Unspecified carbon intensity forecast service, "
+            f"using {api}"
+        )
+    try:
+        return API_interfaces[api]
+    except KeyError:
+        logging.error(
+            f"Error: {api} is not a valid API choice. It must be one of "
+            "\n".join(API_interfaces.keys())
+        )

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -18,6 +18,8 @@ import requests
 
 from .CI_api_interface import API_interfaces, APIInterface
 
+__all__ = ["configure"]
+
 
 def configure(args) -> tuple[dict, APIInterface, str, int]:
     """Return the runtime cats configuration from list of command line

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -9,12 +9,13 @@ configuration consits of:
 - Interface to carbon intensity forecast provider (See TODO)
 
 """
-from collections.abc import Mapping
+
 import logging
+from collections.abc import Mapping
 from typing import Any
 
-import yaml
 import requests
+import yaml
 
 from .CI_api_interface import API_interfaces, APIInterface
 
@@ -74,17 +75,17 @@ def CI_API_from_config_or_args(args, config) -> APIInterface:
     try:
         api = args.api if args.api else config["api"]
     except KeyError:
-        api = 'carbonintensity.org.uk'  # default value
+        api = "carbonintensity.org.uk"  # default value
         logging.warning(
-            "Unspecified carbon intensity forecast service, "
-            f"using {api}"
+            "Unspecified carbon intensity forecast service, " f"using {api}"
         )
     try:
         return API_interfaces[api]
     except KeyError:
         logging.error(
-            f"Error: {api} is not a valid API choice. It must be one of "
-            "\n".join(API_interfaces.keys())
+            f"Error: {api} is not a valid API choice. It must be one of " "\n".join(
+                API_interfaces.keys()
+            )
         )
 
 
@@ -101,7 +102,6 @@ def get_location_from_config_or_args(args, config) -> str:
     r = requests.get("https://ipapi.co/json").json()
     location = r["postal"]
     logging.warning(
-        "location not provided. Estimating location from IP address: "
-        f"{location}."
+        "location not provided. Estimating location from IP address: " f"{location}."
     )
     return location

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -1,8 +1,8 @@
 """This module exports a function :py:func:`configure
 <cats.configure.configure>` that processes both command line arguments
-and configuration file. This function returns a configuration for cats
-to make a request to a carcon intensity forecast provider.  A
-configuration consits of:
+and configuration file. This function returns a runtime configuration
+for cats to make a request to a carcon intensity forecast provider.  A
+runtime configuration consits of:
 
 - location (postcode)
 - job duration

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -77,9 +77,7 @@ def CI_API_from_config_or_args(args, config) -> APIInterface:
         api = args.api if args.api else config["api"]
     except KeyError:
         api = "carbonintensity.org.uk"  # default value
-        logging.warning(
-            "Unspecified carbon intensity forecast service, " f"using {api}"
-        )
+        logging.warning(f"Unspecified carbon intensity forecast service, using {api}")
     try:
         return API_interfaces[api]
     except KeyError:
@@ -93,7 +91,7 @@ def CI_API_from_config_or_args(args, config) -> APIInterface:
 def get_location_from_config_or_args(args, config) -> str:
     if args.location:
         location = args.location
-        logging.info(f"Using location provided: {location}")
+        logging.info(f"Using location provided from command line: {location}")
         return location
     if "location" in config.keys():
         location = config["location"]
@@ -111,6 +109,6 @@ def get_location_from_config_or_args(args, config) -> str:
     location = r.json()["postal"]
     assert location
     logging.warning(
-        "location not provided. Estimating location from IP address: " f"{location}."
+        f"location not provided. Estimating location from IP address: {location}."
     )
     return location

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -8,6 +8,7 @@ forecast provider.  A configuration consits of:
 - Interface to carbon intensity forecast provider (See TODO)
 """
 from collections.abc import Mapping
+import logging
 from typing import Any
 
 import yaml
@@ -28,13 +29,13 @@ def configure(args):
         logging.eror(msg)
         raise ValueError
     if duration <= 0:
-        logger.error(msg)
+        logging.error(msg)
         raise ValueError
 
     return configmapping, CI_API_interface, location, duration
 
 
-def config_from_file(configpath = "") -> Mapping[str, Any]:
+def config_from_file(configpath="") -> Mapping[str, Any]:
     if configpath:
         # if path to config file provided, it is used
         with open(configpath, "r") as f:

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -1,11 +1,13 @@
-"""This module exports a function that processes both command line
-arguments and configuration file. This function returns a
-configuration for cats to make a request to a carcon intensity
-forecast provider.  A configuration consits of:
+"""This module exports a function :py:func:`configure
+<cats.configure.configure>` that processes both command line arguments
+and configuration file. This function returns a configuration for cats
+to make a request to a carcon intensity forecast provider.  A
+configuration consits of:
 
-- location
+- location (postcode)
 - job duration
 - Interface to carbon intensity forecast provider (See TODO)
+
 """
 from collections.abc import Mapping
 import logging
@@ -17,7 +19,21 @@ import requests
 from .CI_api_interface import API_interfaces, APIInterface
 
 
-def configure(args):
+def configure(args) -> tuple[dict, APIInterface, str, int]:
+    """Return the runtime cats configuration from list of command line
+    arguments and content of configuration file.
+
+    Returns a tupe containing a dictionary reprensenting the
+    configuration file, an instance of :py:class:`APIInterface
+    <cats.CI_api_interface.APIInterface>`, the location as a string
+    and the duration in minutes as an integer.
+
+    :param args: Command line arguments
+    :return: Runtime cats configuration
+    :rtype: tuple[dict, APIInterface, str, int]
+    :raises ValueError: If job duration cannot be interpreted as a positive integer.
+
+    """
     configmapping = config_from_file(configpath=args.config)
     CI_API_interface = CI_API_from_config_or_args(args, configmapping)
     location = get_location_from_config_or_args(args, configmapping)

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -1,0 +1,35 @@
+"""This module exports a function that processes both command line
+arguments and configuration file. This function returns a
+configuration for cats to make a request to a carcon intensity
+forecast provider.  A configuration consits of:
+
+- location
+- job duration
+- Interface to carbon intensity forecast provider (See TODO)
+"""
+from collections.abc import Mapping
+from typing import Any
+
+import yaml
+
+
+def configure(args):
+    configmapping = config_from_file(configpath=args.config)
+    return configmapping
+
+
+def config_from_file(configpath = "") -> Mapping[str, Any]:
+    if configpath:
+        # if path to config file provided, it is used
+        with open(configpath, "r") as f:
+            return yaml.safe_load(f)
+        logging.info(f"Using provided config file: {configpath}\n")
+    else:
+        # if no path provided, look for `config.yml` in current directory
+        try:
+            with open("config.yml", "r") as f:
+                return yaml.safe_load(f)
+            logging.info("Using config.yml found in current directory\n")
+        except FileNotFoundError:
+            logging.warning("config file not found")
+            return {}

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -20,10 +20,10 @@ import yaml
 
 from .CI_api_interface import API_interfaces, APIInterface
 
-__all__ = ["configure"]
+__all__ = ["get_runtime_config"]
 
 
-def configure(args) -> tuple[dict, APIInterface, str, int]:
+def get_runtime_config(args) -> tuple[dict, APIInterface, str, int]:
     """Return the runtime cats configuration from list of command line
     arguments and content of configuration file.
 

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -11,6 +11,7 @@ runtime configuration consits of:
 """
 
 import logging
+import sys
 from collections.abc import Mapping
 from typing import Any
 
@@ -99,8 +100,16 @@ def get_location_from_config_or_args(args, config) -> str:
         logging.info(f"Using location from config file: {location}")
         return location
 
-    r = requests.get("https://ipapi.co/json").json()
-    location = r["postal"]
+    r = requests.get("https://ipapi.co/json/")
+    if r.status_code != 200:
+        logging.error(
+            "Could not get location from ipapi.co.\n"
+            f"Got Error {r.status_code} - {r.json()['reason']}\n"
+            f"{r.json()['message']}"
+        )
+        sys.exit(1)
+    location = r.json()["postal"]
+    assert location
     logging.warning(
         "location not provided. Estimating location from IP address: " f"{location}."
     )

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -21,7 +21,17 @@ def configure(args):
     CI_API_interface = CI_API_from_config_or_args(args, configmapping)
     location = get_location_from_config_or_args(args, configmapping)
 
-    return configmapping, CI_API_interface, location
+    msg = "Job duration must be a positive integer (number of minutes)"
+    try:
+        duration = int(args.duration)
+    except ValueError:
+        logging.eror(msg)
+        raise ValueError
+    if duration <= 0:
+        logger.error(msg)
+        raise ValueError
+
+    return configmapping, CI_API_interface, location, duration
 
 
 def config_from_file(configpath = "") -> Mapping[str, Any]:

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -23,6 +23,12 @@ Modules
 .. automodule:: cats.__main__
     :members:
 
+``cats.configure``
+^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: cats.configure
+   :members:
+
 ``cats.CI_api_interface``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -24,7 +24,7 @@ Modules
     :members:
 
 ``cats.configure``
-^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^
 
 .. automodule:: cats.configure
    :members:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -7,7 +7,9 @@ import yaml
 
 from cats.configure import config_from_file
 from cats.configure import get_location_from_config_or_args
+from cats.configure import CI_API_from_config_or_args
 from cats import parse_arguments
+from cats.CI_api_interface import API_interfaces
 
 CATS_CONFIG = {
     "location": "EH8",
@@ -57,3 +59,22 @@ def test_get_location_from_config_or_args():
     config = {}
     location = get_location_from_config_or_args(args, config)
     assert location != ""
+
+def get_CI_API_from_config_or_args(args, config):
+    expected_interface = API_interfaces["carbonintensity.org.uk"]
+    args = parse_arguments().parse_args(
+        ["--api", "carbonintensity.org.uk", "--duration", "1"]
+    )
+    API_interface = CI_API_from_config_or_args(args, CATS_CONFIG)
+    assert API_interface == expected_interface
+
+    args = parse_arguments().parse_args(["--duration", "1"])
+    API_interface = CI_API_from_config_or_args(args, CATS_CONFIG)
+    assert API_interface == expected_interface
+
+    args = parse_arguments().parse_args(
+        ["--api", "doesnotexist.co.uk", "--duration", "1"]
+    )
+    API_interface = CI_API_from_config_or_args(args, CATS_CONFIG)
+    with pytest.raises(KeyError):
+        CI_API_from_config_or_args(args, CATS_CONFIG)

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,20 +1,22 @@
-from contextlib import contextmanager
-from pathlib import Path
 import os
+from contextlib import contextmanager
 
 import pytest
 import yaml
 
-from cats.configure import config_from_file
-from cats.configure import get_location_from_config_or_args
-from cats.configure import CI_API_from_config_or_args
 from cats import parse_arguments
 from cats.CI_api_interface import API_interfaces
+from cats.configure import (
+    CI_API_from_config_or_args,
+    config_from_file,
+    get_location_from_config_or_args,
+)
 
 CATS_CONFIG = {
     "location": "EH8",
     "api": "carbonintensity.org.uk",
 }
+
 
 @contextmanager
 def change_dir(p):
@@ -38,10 +40,12 @@ def test_config_from_file():
         config_from_file(missing_file)
         config_from_file()
 
+
 def test_config_from_file_default(local_config_file):
     with change_dir(local_config_file):
         configmapping = config_from_file()
     assert configmapping == CATS_CONFIG
+
 
 def test_get_location_from_config_or_args():
     expected_location = "SW7"
@@ -59,6 +63,7 @@ def test_get_location_from_config_or_args():
     config = {}
     location = get_location_from_config_or_args(args, config)
     assert location != ""
+
 
 def get_CI_API_from_config_or_args(args, config):
     expected_interface = API_interfaces["carbonintensity.org.uk"]

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,0 +1,59 @@
+from contextlib import contextmanager
+from pathlib import Path
+import os
+
+import pytest
+import yaml
+
+from cats.configure import config_from_file
+from cats.configure import get_location_from_config_or_args
+from cats import parse_arguments
+
+CATS_CONFIG = {
+    "location": "EH8",
+    "api": "carbonintensity.org.uk",
+}
+
+@contextmanager
+def change_dir(p):
+    current_dir = os.getcwd()
+    os.chdir(p)
+    yield
+    os.chdir(current_dir)
+
+
+@pytest.fixture
+def local_config_file(tmp_path_factory):
+    p = tmp_path_factory.mktemp("temp") / "config.yml"
+    with open(p, "w") as stream:
+        yaml.dump(CATS_CONFIG, stream)
+    return p.parent
+
+
+def test_config_from_file():
+    missing_file = "missing.yaml"
+    with pytest.raises(FileNotFoundError):
+        config_from_file(missing_file)
+        config_from_file()
+
+def test_config_from_file_default(local_config_file):
+    with change_dir(local_config_file):
+        configmapping = config_from_file()
+    assert configmapping == CATS_CONFIG
+
+def test_get_location_from_config_or_args():
+    expected_location = "SW7"
+    args = parse_arguments().parse_args(
+        ["--location", expected_location, "--duration", "1"]
+    )
+    location = get_location_from_config_or_args(args, CATS_CONFIG)
+    assert location == expected_location
+
+    args = parse_arguments().parse_args(["--duration", "1"])
+    location = get_location_from_config_or_args(args, CATS_CONFIG)
+    assert location == CATS_CONFIG["location"]
+
+    args = parse_arguments().parse_args(["--duration", "1"])
+    config = {}
+    location = get_location_from_config_or_args(args, config)
+    assert location != ""


### PR DESCRIPTION
The configuration for cats is specified by both a config file and cli arguments. Values provided at the command line often
override the values provided in the config file. It means there is a bit of work to be done in order to distil all that information into a fixed runtime configuration before cats can start making a request to a CI service. Namely, cats needs
- The location
- The APIInterface instance that prescribes how to contact the CI service
- The job duration

This PR moves the processing required to set these three things (the cats runtime configuration) into a separate module `configure` that provides a single `configure` function as an entry point. Benefits are:

- Less code in `__init__.py` which is starting get big
- Easier to add unit tests around the processing of config file and cli arguments