### PR TITLE
Turn on static type checks in the CI (and have them pass)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
@@ -39,6 +39,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Check types with mypy
+      run: |
+        python3 -m pip install '.[types]'
+        python3 -m mypy cats
     - name: Test with pytest
       run: |
         python3 -m pytest --cov

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -218,7 +218,7 @@ class CATSOutput:
 def schedule_at(output: CATSOutput, args: list[str]) -> None:
     "Schedule job with optimal start time using at(1)"
     proc = subprocess.Popen(args, stdout=subprocess.PIPE)
-    output = subprocess.check_output(
+    proc_output = subprocess.check_output(
         (
             "at",
             "-t",
@@ -228,7 +228,7 @@ def schedule_at(output: CATSOutput, args: list[str]) -> None:
     )
 
 
-def main(arguments=None) -> Optional[int]:
+def main(arguments=None) -> int:
     parser = parse_arguments()
     args = parser.parse_args(arguments)
     if args.command and not args.scheduler:
@@ -286,6 +286,7 @@ def main(arguments=None) -> Optional[int]:
         print(output)
     if args.command and args.scheduler == "at":
         schedule_at(output, args.command.split())
+    return 0
 
 
 if __name__ == "__main__":

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -268,6 +268,8 @@ def main(arguments=None) -> int:
     ################################
 
     if args.footprint:
+        assert PUE is not None, "PUE not set by get_runtime_config!"
+        assert jobinfo is not None, "jobinfo not set by get_runtime_config!"
         output.emmissionEstimate = get_footprint_reduction_estimate(
             PUE=PUE,
             jobinfo=jobinfo,

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -13,7 +13,7 @@ runtime configuration consits of:
 import logging
 import sys
 from collections.abc import Mapping
-from typing import Any
+from typing import Optional, Any
 
 import requests
 import yaml
@@ -24,7 +24,9 @@ from .constants import MEMORY_POWER_PER_GB
 __all__ = ["get_runtime_config"]
 
 
-def get_runtime_config(args) -> tuple[dict, APIInterface, str, int]:
+def get_runtime_config(args) -> tuple[APIInterface, str, int, 
+                                      Optional[list[tuple[int, float]]],
+                                      Optional[float]]:
     """Return the runtime cats configuration from list of command line
     arguments and content of configuration file.
 

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -47,7 +47,7 @@ def get_runtime_config(args) -> tuple[dict, APIInterface, str, int]:
     try:
         duration = int(args.duration)
     except ValueError:
-        logging.eror(msg)
+        logging.error(msg)
         raise ValueError
     if duration <= 0:
         logging.error(msg)
@@ -91,13 +91,14 @@ def CI_API_from_config_or_args(args, config) -> APIInterface:
         api = "carbonintensity.org.uk"  # default value
         logging.warning(f"Unspecified carbon intensity forecast service, using {api}")
     try:
-        return API_interfaces[api]
+        interface = API_interfaces[api]
     except KeyError:
         logging.error(
             f"Error: {api} is not a valid API choice. It must be one of " "\n".join(
                 API_interfaces.keys()
             )
         )
+    return interface
 
 
 def get_location_from_config_or_args(args, config) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@
 
   [project.optional-dependencies]
     test = ["pytest", "numpy>=1.5.0", "pytest-subprocess==1.5.0", "pytest-cov"]
+    types = ["mypy", "types-PyYAML", "types-redis", "types-requests", "types-ujson"]
 
   [project.urls]
     Home = "https://github.com/GreenScheduler/cats"


### PR DESCRIPTION
A reasonable amount to this, but it only (a) enabled type checking in our CI workflow and (b) makes this pass. It's a rebase of a previous PR with commits reorganised.

With the changes to get_runtime_config's return types, I think I agree with @tlestang that this is one of those places where type checking isn't really worth it. But if we don't do anything about it we cannot really do type checking elsewhere. I think (as I say in fb01f50dcc327b7c830b4cf07142dff16a76cc2d) that fact that we check `args.footprint` in two places isn't ideal (what if we rename the argument) but I wouldn't worry too much about that unless we actually want to further refactor. Anyway, I kept all of that in a single commit.

The other changes are (I think) pretty straightforward. I've incorporated the changes suggested by @abhidg in the previous PR.