### PR TITLE
Have tests report coverage in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,4 +41,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        python3 -m pytest
+        python3 -m pytest --cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@
   dependencies = ["requests-cache>=1.0", "PyYAML>=6.0"]
 
   [project.optional-dependencies]
-    test = ["pytest", "numpy>=1.5.0", "pytest-subprocess==1.5.0"]
+    test = ["pytest", "numpy>=1.5.0", "pytest-subprocess==1.5.0", "pytest-cov"]
 
   [project.urls]
     Home = "https://github.com/GreenScheduler/cats"


### PR DESCRIPTION
This will help us keep track of current test coverage - it's a simple change to the CI and dependancies. One thing to (maybe) think about is how these get reported (e.g. can we make github cache the previous coverage and use that to see if we are doing better). I'm happy for this to be merged or to leave it hanging around with more work needed.