### PR TITLE
ci: upload coverage to codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
@@ -42,3 +42,8 @@ jobs:
     - name: Test with pytest
       run: |
         python3 -m pytest --cov
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == 3.9
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This will need somebody with admin access to set the `CODECOV_TOKEN` in GitHub Secrets from https://app.codecov.io/github/GreenScheduler/cats/settings