### PR TITLE
Change CLI argument name in Quickstart documentation

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -14,7 +14,7 @@ You can run CATS with:
 
    $ cats --duration 480 --location "EH8"
 
-The ``--postcode`` option is optional, and can be pulled from a
+The ``--location`` option is optional, and can be pulled from a
 configuration file (see :ref:`configuration-file`), or inferred using
 the server's IP address.
 


### PR DESCRIPTION
At a glance, it looks like `--postcode` should be `--location`.