### PR TITLE
Adds option to specify config location using env variable

### DIFF
--- a/cats/configure.py
+++ b/cats/configure.py
@@ -12,6 +12,7 @@ runtime configuration consits of:
 
 import logging
 import sys
+import os
 from collections.abc import Mapping
 from typing import Any, Optional
 
@@ -76,7 +77,16 @@ def config_from_file(configpath="") -> Mapping[str, Any]:
             return yaml.safe_load(f)
         logging.info(f"Using provided config file: {configpath}\n")
     else:
-        # if no path provided, look for `config.yml` in current directory
+        # if no path provided, try to use config environment variable
+        cfile = os.getenv("CATS_CONFIG_FILE")
+        if cfile is not None:
+            try:
+                with open(cfile, "r") as f:
+                    return yaml.safe_load(f)
+                logging.info("Using config.yml found in CATS_CONFIG_FILE\n")
+            except FileNotFoundError:
+                logging.warning("CATS_CONFIG_FILE config file not found")
+        # if no path provided and no env variable, look for `config.yml` in current directory
         try:
             with open("config.yml", "r") as f:
                 return yaml.safe_load(f)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -45,12 +45,21 @@ Use the ``--config`` option to specify a path to the configuration
 file, relative to the current directory.
 
 In case of a missing location command line argument, ``cats`` looks
-for a file named ``config.yaml`` in the current directory.
+first in the ``CATS_CONFIG_FILE`` environment variable and if that
+is not set it looks for a file named ``config.yaml`` in the current directory.
 
 .. code-block:: shell
 
    #  Override duration value at the command line
    cats --config /path/to/config.yaml --location "OX1"
+
+.. code-block:: shell
+
+   # location information is provided by the file
+   # specified in $CATS_CONFIG_FILE
+   # If not, it looks for ./config.yaml
+   export CATS_CONFIG_FILE=/path/to/config.yaml
+   cats --duration 480
 
 .. code-block:: shell
 


### PR DESCRIPTION
Adds the option to set `CATS_CONFIG_FILE` environment variable to specify config file location. Config file location precedence becomes:

1. Command line option
2. Location specified in `CATS_CONFIG_FILE`
3. `./config.yaml`