### PR TITLE
Plot the carbon intensity time serise

### DIFF
--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -14,6 +14,7 @@ from .CI_api_query import get_CI_forecast  # noqa: F401
 from .configure import get_runtime_config
 from .forecast import CarbonIntensityAverageEstimate
 from .optimise_starttime import get_avg_estimates  # noqa: F401
+from .plotting import plotplan
 
 __version__ = "1.0.0"
 
@@ -182,6 +183,11 @@ def parse_arguments():
         type=positive_integer,
         help="Amount of memory used by the job, in GB",
     )
+    parser.add_argument(
+        "--plot",
+        help="Create a plot of the forcast and optimised plan for the job",
+        action="store_true",
+    )
 
     return parser
 
@@ -312,6 +318,8 @@ This is usually due to forecast limitations."""
         print(output.to_json(dateformat, sort_keys=True, indent=2))
     else:
         print(output)
+    if args.plot:
+        plotplan(CI_forecast, output)
     if args.command and args.scheduler == "at":
         if err := schedule_at(output, args.command.split()):
             print(err)

--- a/cats/plotting.py
+++ b/cats/plotting.py
@@ -1,0 +1,38 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+def plotplan(CI_forecast, output):
+    """
+    Plot the carbon intensity forcast and optimised plan
+    """
+    # Just for now pull the CI forecast apart... probably belongs as method...
+    values = []
+    times = []
+    now_values = []
+    now_times = []
+    opt_values = []
+    opt_times = []
+    for point in CI_forecast:
+        values.append(point.value)
+        times.append(point.datetime)
+        if (point.datetime >= output.carbonIntensityOptimal.start and
+            point.datetime <= output.carbonIntensityOptimal.end):
+            opt_values.append(point.value)
+            opt_times.append(point.datetime)
+        if (point.datetime >= output.carbonIntensityNow.start and
+            point.datetime <= output.carbonIntensityNow.end):
+            now_values.append(point.value)
+            now_times.append(point.datetime)
+
+    # Make the plot (should probably take fig and ax as opt args...)
+    fig, ax = plt.subplots()
+    ax.fill_between(times, 0.0, values, alpha=0.2, color='b')
+    ax.fill_between(now_times, 0.0, now_values, alpha=0.6,  color='r')
+    ax.fill_between(opt_times, 0.0, opt_values, alpha=0.6, color='g')
+    ax.set_xlabel("Time (mm-dd hh)")
+    ax.set_ylabel("Forecast carbon intensity (gCO2eq/kWh)")
+    ax.grid(True)
+    ax.label_outer()
+    fig.autofmt_xdate()
+    plt.show()
+    return None


### PR DESCRIPTION
Just a proof of concept for now, but plots the CI forecast time series alongside our planned run times. 

Currently looks like this:

![cats_plot](https://github.com/user-attachments/assets/b325e1b9-1178-4f2f-bdd2-b24df9cfd6aa)

I think the optimal and now plots (green and red, respectively) are 30 mins out. Or background data is 30 mins out. Anyhow, this is a start.