### PR TITLE
Display sbatch output

### DIFF
--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -303,7 +303,7 @@ def schedule_sbatch(output: CATSOutput, args: list[str]) -> Optional[str]:
                 *args,
             ]
         )
-        print(sbatch_output)
+        print(sbatch_output.decode("utf-8"))
         return None
     except FileNotFoundError:
         return "No sbatch command found in PATH, ensure slurm is configured correctly"

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -293,7 +293,7 @@ def schedule_sbatch(output: CATSOutput, args: list[str]) -> Optional[str]:
     :return: Error as a string, or None if successful
     """
     try:
-        subprocess.check_output(
+        sbatch_output = subprocess.check_output(
             [
                 "sbatch",
                 "--begin",
@@ -303,6 +303,7 @@ def schedule_sbatch(output: CATSOutput, args: list[str]) -> Optional[str]:
                 *args,
             ]
         )
+        print(sbatch_output)
         return None
     except FileNotFoundError:
         return "No sbatch command found in PATH, ensure slurm is configured correctly"


### PR DESCRIPTION
Fixes issue #137 and displays the output of sbatch (e.g. "Submitted batch job 127"). 

It turns out that `at` displays the job number/status via stderr and that is what was causing it to appear on screen. `Sbatch` uses stdout, so this code captures and displays that output. 

 