### PR TITLE
Add testing for python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This is the current python stable relase. 3.9 goes out of security support in a month or two, so we should update the requierments then. This also gives us a chance to check the new MacOS test runners on github work for us.