### PR TITLE
Improve plot output (hatching, unit formatting, mean lines, etc.)

### DIFF
--- a/cats/plotting.py
+++ b/cats/plotting.py
@@ -230,17 +230,16 @@ def plotplan(CI_forecast, output):
             # around that it pushes the x axis label off the figure below
             date_bold = dt.strftime(r"\mathbf{%y\text{-}%m\text{-}%d}")
             time_part = dt.strftime("%H:%M")
-            return f"${date_bold}\ {time_part}$"
-
-        # All other ticks → ellipsis + time
-        time_part = dt.strftime("%H:%M")
-        return f"$\ldots\ {time_part}$"
+            return rf"${date_bold}\ {time_part}$"
+        else:
+            # All other ticks get ellipsis + time
+            time_part = dt.strftime("%H:%M")
+            return rf"$\ldots\ {time_part}$"
 
     # The x axis label needs some padding at the figure foot else it gets a
     # bit cut off due to the length of some datetime x labels
     ax.set_xlabel(r"Time ($\mathbf{yy\text{-}mm\text{-}dd}$ hh:mm)")
     ax.xaxis.set_major_formatter(FuncFormatter(tick_formatting))
-    ax.xaxis.set_minor_formatter(mdates.DateFormatter("%y-%m-%d %H:%M"))
     ax.set_ylabel(rf"Forecast carbon intensity ({units})")
     ax.label_outer()
 


### PR DESCRIPTION
Address points in #153, excluding unit tests for plotting (best set those up once we agree on what the output plot should look like, IMO, to save any need to continuously tweak the desired output images to test against), with some further plotting improvements thrown in for good measure (call me sad but I enjoy making a nice plot 🙂 ).

All up for discussion and happy to edit or revert anything if folks don't like it - but I for one think the time series plot (shown with `--plot`) from our POC plot PR is much more readable, accessible and good-looking after these updates.

## Updates

This PR implements the following:

* applies an [accessible style sheet](https://matplotlib.org/stable/gallery/style_sheets/style_sheets_reference.html) from the matploltib and colours so that those e.g. with some form of colour blindness can understand the plot better  - without relying on colour to convey anything (e.g. hatching also distinguishes the two job run windows, see below) esp. by adding a legend to stop red and green being the only way to tell apart the now and optimal cases;
* add hatching in different directions to emphasise and distinguish the two windows and make the nature of the overlap region clear, plus window black borders for emphasis against the CI forecast background;
* if there is an overlap, as determined by the optimal run start value and now run end value, add a patch corresponding to the style of the overlap region to the legend (otherwise leave it off the legend to avoid cluttering it);
* start y axis at 0 to remove gap below CI filled-in curve, (though leave the gaps to each side of the x axis because that makes clear the 48-hour window extent of the CI forecast which I think is useful, else it could be assumed it goes on further at least to the right for later times);
* unit formatting, noting that to avoid the need to check for (La)TeX availability on the local system, we can use the Mathtext lightweight formatter bundled with matploltib itself;
* add horizontal dashed lines to illustrate the mean for the and optimal values, helping to illustrate the two quoted CI figures in context of the plotted windows;
* format datetimes on x axis tick labels so that the date is only shown against the day start (might be easier to see what I mean by looking at the 'after' output plots below) making it IMO much quicker to comprehend the datetime span;
* improve the formatting of the title to avoid duplication of units and other text, etc;
* add some small subtle scatter points to show the actual forecast values, which I think it nice in terms of making any interpolation for the trend line clear.

## Before and after

I used the following command near to time of posting to test: `cats -d 100 --loc RG2 --plot` ('no overlap' examples) and `cats -d 600 --loc RG2 --plot` (overlap examples). Starting with after, since that's the output from this PR so most relevant...

### After (result on this/PR branch)

#### Example with no overlap of windows

<img width="700" height="550" alt="cats_prver_nooverlap" src="https://github.com/user-attachments/assets/364171b1-8295-48c6-ad40-a3a0453d2c73" />

#### Example with overlap of windows

<img width="700" height="550" alt="cats_prver_withoverlap" src="https://github.com/user-attachments/assets/0ece372a-92c4-44e6-8f36-3696e746b386" />

### Before (result on `main` branch)

#### Example with no overlap of windows

<img width="640" height="480" alt="cats_main_nooverlap" src="https://github.com/user-attachments/assets/9371b3ec-6723-48c3-9725-607f6c435050" />

#### Example with overlap of windows

<img width="640" height="480" alt="cats_main_withoverlap" src="https://github.com/user-attachments/assets/0dc32a25-cadf-421e-ba30-da9918bb5f88" />
