### PR TITLE
Add and document a CATS User-agent

### DIFF
--- a/cats/CI_api_query.py
+++ b/cats/CI_api_query.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 import requests_cache
 
 from .forecast import CarbonIntensityPointEstimate
-
+from . import _user_agent
 
 def get_CI_forecast(
     location: str, CI_API_interface
@@ -24,7 +24,8 @@ def get_CI_forecast(
 
     # get the carbon intensity api data
     r = session.get(
-        CI_API_interface.get_request_url(datetime.now(timezone.utc), location)
+        CI_API_interface.get_request_url(datetime.now(timezone.utc), location),
+        headers = _user_agent
     )
     data = r.json()
 

--- a/cats/CI_api_query.py
+++ b/cats/CI_api_query.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 import requests_cache
 
 from .forecast import CarbonIntensityPointEstimate
-from . import _user_agent
+from .version import user_agent
 
 def get_CI_forecast(
     location: str, CI_API_interface
@@ -25,7 +25,7 @@ def get_CI_forecast(
     # get the carbon intensity api data
     r = session.get(
         CI_API_interface.get_request_url(datetime.now(timezone.utc), location),
-        headers = _user_agent
+        headers = user_agent
     )
     data = r.json()
 

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -21,6 +21,7 @@ from .forecast import (
 )
 
 __version__ = "1.1.0"
+_user_agent = {'User-agent:': f'CATS/{__version__} +https://cats.readthedocs.io/'}
 
 # To add a scheduler, add a date format here
 # and create a scheduler_<new>(...) function

--- a/cats/__init__.py
+++ b/cats/__init__.py
@@ -19,9 +19,7 @@ from .forecast import (
     CarbonIntensityAverageEstimate,
     WindowedForecast,
 )
-
-__version__ = "1.1.0"
-_user_agent = {'User-agent:': f'CATS/{__version__} +https://cats.readthedocs.io/'}
+from .version import version as __version__
 
 # To add a scheduler, add a date format here
 # and create a scheduler_<new>(...) function

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -22,6 +22,7 @@ import yaml
 
 from .CI_api_interface import API_interfaces, APIInterface
 from .constants import MEMORY_POWER_PER_GB
+from . import _user_agent
 
 __all__ = ["get_runtime_config"]
 # Patch requests to cache location API calls (and allow CI to still work)
@@ -133,7 +134,7 @@ def get_location_from_config_or_args(args, config) -> str:
         logging.info(f"Using location from config file: {location}")
         return location
 
-    r = requests.get("https://ipapi.co/json/")
+    r = requests.get("https://ipapi.co/json/", headers = _user_agent)
     if r.status_code != 200:
         logging.error(
             "Could not get location from ipapi.co.\n"

--- a/cats/configure.py
+++ b/cats/configure.py
@@ -22,7 +22,7 @@ import yaml
 
 from .CI_api_interface import API_interfaces, APIInterface
 from .constants import MEMORY_POWER_PER_GB
-from . import _user_agent
+from .version import user_agent
 
 __all__ = ["get_runtime_config"]
 # Patch requests to cache location API calls (and allow CI to still work)
@@ -134,7 +134,7 @@ def get_location_from_config_or_args(args, config) -> str:
         logging.info(f"Using location from config file: {location}")
         return location
 
-    r = requests.get("https://ipapi.co/json/", headers = _user_agent)
+    r = requests.get("https://ipapi.co/json/", headers = user_agent)
     if r.status_code != 200:
         logging.error(
             "Could not get location from ipapi.co.\n"

--- a/cats/version.py
+++ b/cats/version.py
@@ -1,2 +1,2 @@
-version = "1.1.0"
-user_agent = {'User-agent': f'CATS/{version} +https://cats.readthedocs.io/'}
+version = "1.1.0" #: The CATS semantic version
+user_agent = {'User-agent': f'CATS/{version} +https://cats.readthedocs.io/'} #: HTTP user-agent used for API calls

--- a/cats/version.py
+++ b/cats/version.py
@@ -1,0 +1,2 @@
+version = "1.1.0"
+user_agent = {'User-agent': f'CATS/{version} +https://cats.readthedocs.io/'}

--- a/docs/source/api-reference.rst
+++ b/docs/source/api-reference.rst
@@ -17,6 +17,12 @@ Modules
 .. automodule:: cats
     :members:
 
+``cats.version``
+^^^^^^^^^^^^^^^^^
+
+.. automodule:: cats.version
+    :members:
+
 ``cats.configure``
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,7 @@ cluster jobs to minimize predicted carbon intensity of running the process.
    use-with-schedulers.rst
    cli-reference.rst
    api-reference.rst
+   user-agent.rst
    contributing.rst
 
 

--- a/docs/source/user-agent.rst
+++ b/docs/source/user-agent.rst
@@ -1,0 +1,32 @@
+.. _user-agent:
+
+Use of HTTP APIs, caching and the CATS User-agent
+=================================================
+
+In order to function CATS makes HTTP based API calls to services
+that provide a forecast of future grid carbon intensity and, in
+some cases, to attempt to find the physical location of the computer
+running CATS (because grid carbon intensity is different in different
+locations, even if they are using the same synchronized national power
+distribution network). CATS makes use of local caching to minimize the
+number of times that these services are used and sets its User-agent
+header to help API providers manage their services.
+
+The CATS HTTP User-agent header is::
+    
+     CATS/version +https://cats.readthedocs.io/
+     
+where version corresponds to the version number stored in ``cats.__version__``.
+
+For a single user and on a single system CATS will request carbon intensity
+information at most once in any half-hour period. This is achieved by setting
+the start time embedded in the URL used to request data to the most recent 
+half- or whole-hour time. The ``requests_cache`` package then intercepts 
+subsequent API calls and returns data without making a new HTTP call to the
+carbon intensity service.
+
+CATS only attempts to find the location of the computer where it is running
+if the location is not set on the command line or in the configuration file.
+In the absence of this information, CATS will make use of the https://ipapi.co/
+service, which geolocates the IP address on best-effort basis. These API calls are
+also cached.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@
   dependencies = ["requests-cache>=1.0", "PyYAML>=6.0"]
 
   [tool.setuptools.dynamic]
-    version = {attr = "cats.__version__"}
+    version = {attr = "cats.version.version"}
 
   [tool.pytest.ini_options]
     markers = ["fixt_data: data for fixtures"]


### PR DESCRIPTION
This adds a User-agent header to all CATS HTTP API calls of:

    CATS/version +https://cats.readthedocs.io/

where the version is set according to __version__ in __init__. These headers are added to our calls to the carbon intensity and ipapi APIs.

Add documentation outlining our User-agent header, and our approach to caching.  This hope is that this will mean our calls to ipapi don't get bundled in with
python requests calls when any rate limiting is going on. This should also allow the carbon intensity team to see how much we are (or are not) using their service.