### PR TITLE
Add windows support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -40,6 +40,8 @@ Currently CATS only works in the UK. If you are aware of APIs for
 realtime grid carbon intensity data in other countries, please
 `open an issue <GitHubrepoissues_>`_ to let us know.
 
+CATS is currently tested with Python versions 3.10-3.14 running
+on Linux, Windows and MacOS.
 
 Background
 ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,18 @@
   classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
     "Intended Audience :: System Administrators",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
   ]
   dependencies = ["requests-cache>=1.0", "PyYAML>=6.0", "tzdata ; platform_system == 'Windows'"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@
     "Intended Audience :: Science/Research",
     "Intended Audience :: System Administrators",
   ]
-  dependencies = ["requests-cache>=1.0", "PyYAML>=6.0"]
+  dependencies = ["requests-cache>=1.0", "PyYAML>=6.0", "tzdata ; platform_system == 'Windows'"]
 
   [tool.setuptools.dynamic]
     version = {attr = "cats.version.version"}


### PR DESCRIPTION
Currently we just add windows-latest to CI to see if we can run the test cases with the windows-latest CI test runner at github (which is windows server 2025 running on a x64 VM).

Just needed to add a conditional dependency on tzdata in the pyproject.toml file to make the tests go from failing to passing. It would be good to have a real windows user test it (but that'll need a pip install from this branch rather than from PyPi).

Also document python version and supported OSes.