### PR TITLE
Update NESO hyperlink now showing status code 403

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -4,7 +4,7 @@
 .. _SSIsite: https://www.software.ac.uk/
 .. _CW23page: https://software.ac.uk/cw23
 .. _CW23HackDaypage: https://www.software.ac.uk/cw23/hack-day
-.. _NationalGridESO: https://www.nationalgrideso.com/
+.. _NationalGridESO: https://www.neso.energy/
 .. _CarbonIntensityAPI: https://carbonintensity.org.uk/
 .. _GitHubrepoissues: https://github.com/GreenScheduler/cats/issues
 


### PR DESCRIPTION
The National Grid ESO website now lives under a new domain so the URL we use goes to an intermediate page with a 403 stats code:

```console
$ curl -i https://www.nationalgrideso.com/
HTTP/2 403 
date: Thu, 09 Apr 2026 16:19:17 GMT
content-type: text/html
cache-control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
expires: Thu, 01 Jan 1970 00:00:01 GMT
referrer-policy: same-origin
...
```

showing:

<img width="835" height="518" alt="Screenshot_20260409_170621" src="https://github.com/user-attachments/assets/29079112-25e7-4bf2-b4b8-384ae494bbe5" />

so this PR updates the link, where used, the new location. From a `git grep grideso` we only use the old link in one place, so only one instance needs updating - in [the docs 'Introduction' page](https://cats.readthedocs.io/en/latest/introduction.html).