### PR TITLE
Release v1.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 GreenScheduler
+Copyright (c) 2023-2026 GreenScheduler
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The Climate-Aware Task Scheduler is a lightweight Python package designed to sch
 - Schedules tasks based on the estimated carbon intensity, minimizing carbon emissions
 - Provides a simple and intuitive API for developers
 - Lightweight and easy to integrate into existing workflows
-- Supports Python 3.9+
+- Supports Python 3.10+
 
 ## Brief example with plot to illustrate
 

--- a/cats/version.py
+++ b/cats/version.py
@@ -1,2 +1,2 @@
-version = "1.1.0" #: The CATS semantic version
+version = "1.2.0" #: The CATS semantic version
 user_agent = {'User-agent': f'CATS/{version} +https://cats.readthedocs.io/'} #: HTTP user-agent used for API calls


### PR DESCRIPTION
New version (will need releasing and tagging) including:

* Remove support for Python 3.9, add support for 3.13 and 3.14
* Updates to documentation
* New feature to limit the start and end time to a limited time window (see --start-window and --end-window)
* Improved graphical output showing carbon intensity and optimal run time
* Make CATS installable on Windows (integration with scheduler has not been done)
* Refactoring the "main" function to prepare for additional data sources and scheduling methods
* Improvments to tests, including creation of docker based SLURM cluster for integration testing